### PR TITLE
[codex] Add PreFormServer setup gating and release-gate workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,14 @@ build/
 .coverage
 htmlcov/
 test-results/
+playwright-report/
+test-results/playwright/
 
 # IDE
 .vscode/
 .idea/
 .worktrees/
+node_modules/
 *.swp
 *.swo
 *~

--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ Environment variables:
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/ -q
 ```
 
+## Release Gate
+
+```bash
+npm install
+npx playwright install chromium
+npm run test:release-gate
+```
+
+Prerequisite: a live compatible PreFormServer is reachable at `http://localhost:44388` for the happy-path scenarios.
+
 ## Roadmap
 
 ### Current Repository State

--- a/app/config.py
+++ b/app/config.py
@@ -15,8 +15,17 @@ class Settings:
     data_dir: Path
     uploads_dir: Path
     static_dir: Path
+    appdata_dir: Path
     database_path: Path
+    preform_server_port: int
+    preform_managed_dir: Path
+    preform_managed_executable: Path
     preform_server_url: str
+    preform_server_startup_timeout_s: int
+    preform_server_shutdown_timeout_s: int
+    preform_min_zip_size_bytes: int
+    preform_min_supported_version: str
+    preform_max_supported_version: str | None
     formlabs_api_token: str | None
     formlabs_api_url: str
 
@@ -35,6 +44,17 @@ def build_settings(
     resolved_database_path = database_path or Path(
         os.getenv("ANDENT_WEB_DATABASE_PATH", resolved_data_dir / "andent_web.db")
     )
+    appdata_override = os.getenv("ANDENT_WEB_APPDATA_DIR")
+    if appdata_override:
+        resolved_appdata_root = Path(appdata_override)
+    elif data_dir is not None:
+        resolved_appdata_root = resolved_data_dir / "appdata"
+    else:
+        resolved_appdata_root = Path(os.getenv("APPDATA", resolved_data_dir / "appdata"))
+
+    managed_appdata_dir = resolved_appdata_root / "Andent Web"
+    preform_server_port = int(os.getenv("ANDENT_WEB_PREFORM_PORT", "44388"))
+    preform_managed_dir = managed_appdata_dir / "PreFormServer"
 
     return Settings(
         app_name="Andent Web",
@@ -44,8 +64,29 @@ def build_settings(
         data_dir=resolved_data_dir,
         uploads_dir=resolved_data_dir / "uploads",
         static_dir=app_dir / "static",
+        appdata_dir=managed_appdata_dir,
         database_path=resolved_database_path,
-        preform_server_url=os.getenv("PREFORM_SERVER_URL", "http://localhost:44388"),
+        preform_server_port=preform_server_port,
+        preform_managed_dir=preform_managed_dir,
+        preform_managed_executable=preform_managed_dir / "PreFormServer.exe",
+        preform_server_url=os.getenv(
+            "PREFORM_SERVER_URL",
+            f"http://localhost:{preform_server_port}",
+        ),
+        preform_server_startup_timeout_s=int(
+            os.getenv("ANDENT_WEB_PREFORM_STARTUP_TIMEOUT_S", "30")
+        ),
+        preform_server_shutdown_timeout_s=int(
+            os.getenv("ANDENT_WEB_PREFORM_SHUTDOWN_TIMEOUT_S", "10")
+        ),
+        preform_min_zip_size_bytes=int(
+            os.getenv("ANDENT_WEB_PREFORM_MIN_ZIP_SIZE_BYTES", str(10 * 1024 * 1024))
+        ),
+        preform_min_supported_version=os.getenv(
+            "ANDENT_WEB_PREFORM_MIN_VERSION",
+            "3.55.0",
+        ),
+        preform_max_supported_version=os.getenv("ANDENT_WEB_PREFORM_MAX_VERSION") or None,
         formlabs_api_token=os.getenv("FORMLABS_API_TOKEN"),
         formlabs_api_url=os.getenv("FORMLABS_API_URL", "https://api.formlabs.com/v1"),
     )

--- a/app/database.py
+++ b/app/database.py
@@ -9,7 +9,12 @@ from typing import Iterable
 
 from .config import Settings
 from .schemas import ClassificationRow, DimensionSummary, PrintJob
-from .services.classification import derive_status, generate_thumbnail_svg, is_current_thumbnail_svg
+from .services.classification import (
+    default_preset,
+    derive_status,
+    generate_thumbnail_svg,
+    is_current_thumbnail_svg,
+)
 
 
 SCHEMA_STATEMENTS: tuple[str, ...] = (
@@ -76,6 +81,21 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         layer_height_microns INTEGER,
         estimated_completion TIMESTAMP,
         error_message TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS preform_setup_state (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        readiness TEXT NOT NULL,
+        install_path TEXT NOT NULL,
+        managed_executable_path TEXT NOT NULL,
+        detected_version TEXT,
+        last_health_check_at TEXT,
+        last_error_code TEXT,
+        last_error_message TEXT,
+        active_configured_source INTEGER NOT NULL DEFAULT 1,
+        process_id INTEGER,
+        updated_at TEXT NOT NULL
     )
     """,
 )
@@ -361,6 +381,126 @@ def update_print_job(settings: Settings, job_id: int, **changes: object) -> Prin
         return _fetch_print_job(connection, job_id=job_id)
 
 
+def _default_preform_setup_state(settings: Settings) -> dict[str, object]:
+    return {
+        "id": 1,
+        "readiness": "not_installed",
+        "install_path": str(settings.preform_managed_dir),
+        "managed_executable_path": str(settings.preform_managed_executable),
+        "detected_version": None,
+        "last_health_check_at": None,
+        "last_error_code": None,
+        "last_error_message": None,
+        "active_configured_source": 1,
+        "process_id": None,
+        "updated_at": _now_iso(),
+    }
+
+
+def load_preform_setup_state(settings: Settings) -> dict[str, object]:
+    with closing(connect(settings)) as connection:
+        row = connection.execute(
+            """
+            SELECT *
+            FROM preform_setup_state
+            WHERE id = 1
+            """
+        ).fetchone()
+        if row is None:
+            return _default_preform_setup_state(settings)
+        return {
+            "id": row["id"],
+            "readiness": row["readiness"],
+            "install_path": row["install_path"],
+            "managed_executable_path": row["managed_executable_path"],
+            "detected_version": row["detected_version"],
+            "last_health_check_at": row["last_health_check_at"],
+            "last_error_code": row["last_error_code"],
+            "last_error_message": row["last_error_message"],
+            "active_configured_source": row["active_configured_source"],
+            "process_id": row["process_id"],
+            "updated_at": row["updated_at"],
+        }
+
+
+def save_preform_setup_state(settings: Settings, **changes: object) -> dict[str, object]:
+    current = load_preform_setup_state(settings)
+    payload = {
+        "id": 1,
+        "readiness": changes.get("readiness", current["readiness"]),
+        "install_path": changes.get("install_path", current["install_path"]),
+        "managed_executable_path": changes.get(
+            "managed_executable_path",
+            current["managed_executable_path"],
+        ),
+        "detected_version": changes.get("detected_version", current["detected_version"]),
+        "last_health_check_at": changes.get(
+            "last_health_check_at",
+            current["last_health_check_at"],
+        ),
+        "last_error_code": changes.get("last_error_code", current["last_error_code"]),
+        "last_error_message": changes.get(
+            "last_error_message",
+            current["last_error_message"],
+        ),
+        "active_configured_source": 1
+        if changes.get(
+            "active_configured_source",
+            bool(current["active_configured_source"]),
+        )
+        else 0,
+        "process_id": changes.get("process_id", current["process_id"]),
+        "updated_at": _now_iso(),
+    }
+
+    with closing(connect(settings)) as connection:
+        connection.execute(
+            """
+            INSERT INTO preform_setup_state (
+                id,
+                readiness,
+                install_path,
+                managed_executable_path,
+                detected_version,
+                last_health_check_at,
+                last_error_code,
+                last_error_message,
+                active_configured_source,
+                process_id,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                readiness = excluded.readiness,
+                install_path = excluded.install_path,
+                managed_executable_path = excluded.managed_executable_path,
+                detected_version = excluded.detected_version,
+                last_health_check_at = excluded.last_health_check_at,
+                last_error_code = excluded.last_error_code,
+                last_error_message = excluded.last_error_message,
+                active_configured_source = excluded.active_configured_source,
+                process_id = excluded.process_id,
+                updated_at = excluded.updated_at
+            """,
+            (
+                payload["id"],
+                payload["readiness"],
+                payload["install_path"],
+                payload["managed_executable_path"],
+                payload["detected_version"],
+                payload["last_health_check_at"],
+                payload["last_error_code"],
+                payload["last_error_message"],
+                payload["active_configured_source"],
+                payload["process_id"],
+                payload["updated_at"],
+            ),
+        )
+        connection.commit()
+
+    return payload
+
+
 def delete_print_job(settings: Settings, job_id: int) -> bool:
     with closing(connect(settings)) as connection:
         cursor = connection.execute("DELETE FROM print_jobs WHERE id = ?", (job_id,))
@@ -386,6 +526,17 @@ def _record_event(
         """,
         (row_id, event_type, event_at, json.dumps(metadata or {})),
     )
+
+
+def _normalize_manual_preset(model_type: str | None, preset: str | None) -> str | None:
+    if preset is None:
+        return default_preset(model_type) if model_type else None
+
+    normalized_from_model_label = default_preset(preset)
+    if normalized_from_model_label is not None:
+        return normalized_from_model_label
+
+    return preset
 
 
 def persist_upload_session(settings: Settings, session_id: str, rows: Iterable[dict]) -> list[ClassificationRow]:
@@ -593,6 +744,7 @@ def update_upload_row(
         if existing["status"] in {"Submitted", "Printed"}:
             raise ValueError("Submitted rows are read-only.")
 
+        preset = _normalize_manual_preset(model_type, preset)
         status = existing["status"]
         if status not in {"Duplicate", "Submitted", "Printed"}:
             status = derive_status(existing["confidence"], model_type, preset, manual_override=True)
@@ -702,9 +854,10 @@ def bulk_update_upload_rows(
 
             next_model_type = model_type if model_type is not None else row["model_type"]
             if model_type is not None and preset is None:
-                next_preset = model_type
+                raw_preset = model_type
             else:
-                next_preset = preset if preset is not None else row["preset"]
+                raw_preset = preset if preset is not None else row["preset"]
+            next_preset = _normalize_manual_preset(next_model_type, raw_preset)
             next_status = row["status"]
             if next_status not in {"Duplicate", "Submitted", "Printed"}:
                 next_status = derive_status(row["confidence"], next_model_type, next_preset, manual_override=True)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from .config import Settings, get_settings
 from .database import init_db
 from .routers.uploads import router as uploads_router
 from .routers.metrics import router as metrics_router
+from .routers.preform_setup import router as preform_setup_router
 from .routers.print_queue import router as print_queue_router
 
 
@@ -33,6 +34,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.mount("/static", StaticFiles(directory=str(resolved_settings.static_dir)), name="static")
     app.include_router(uploads_router)
     app.include_router(metrics_router)
+    app.include_router(preform_setup_router)
     app.include_router(print_queue_router)
 
     @app.get("/", include_in_schema=False)

--- a/app/routers/preform_setup.py
+++ b/app/routers/preform_setup.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import APIRouter, File, HTTPException, Request, UploadFile
+
+from ..schemas import PreFormSetupActionResponse, PreFormSetupStatus
+from ..services.preform_setup_service import (
+    PreFormSetupError,
+    PreFormSetupService,
+    get_preform_setup_status,
+)
+
+
+router = APIRouter(prefix="/api/preform-setup", tags=["preform-setup"])
+
+
+def _manager(request: Request) -> PreFormSetupService:
+    return PreFormSetupService(request.app.state.settings)
+
+
+def _temp_zip_path(settings, filename: str | None) -> Path:
+    safe_name = Path(filename or "preformserver.zip").name or "preformserver.zip"
+    temp_dir = settings.data_dir / "preform_setup_uploads"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    return temp_dir / f"{uuid4().hex}-{safe_name}"
+
+
+async def _save_upload(settings, package: UploadFile) -> Path:
+    temp_path = _temp_zip_path(settings, package.filename)
+    with temp_path.open("wb") as handle:
+        shutil.copyfileobj(package.file, handle)
+    await package.close()
+    return temp_path
+
+
+def _action_response(status: PreFormSetupStatus, message: str) -> PreFormSetupActionResponse:
+    return PreFormSetupActionResponse(status=status, message=message)
+
+
+@router.get("/status", response_model=PreFormSetupStatus)
+async def status(request: Request) -> PreFormSetupStatus:
+    return get_preform_setup_status(request.app.state.settings)
+
+
+@router.post("/install-from-zip", response_model=PreFormSetupActionResponse)
+async def install_from_zip(
+    request: Request,
+    package: UploadFile = File(...),
+) -> PreFormSetupActionResponse:
+    settings = request.app.state.settings
+    temp_path = await _save_upload(settings, package)
+    try:
+        status = _manager(request).install_from_zip(temp_path)
+    except PreFormSetupError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return _action_response(status, "PreFormServer installed and verified.")
+
+
+@router.post("/replace-from-zip", response_model=PreFormSetupActionResponse)
+async def replace_from_zip(
+    request: Request,
+    package: UploadFile = File(...),
+) -> PreFormSetupActionResponse:
+    settings = request.app.state.settings
+    temp_path = await _save_upload(settings, package)
+    try:
+        status = _manager(request).replace_from_zip(temp_path)
+    except PreFormSetupError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return _action_response(status, "PreFormServer replaced and re-verified.")
+
+
+@router.post("/start", response_model=PreFormSetupActionResponse)
+async def start(request: Request) -> PreFormSetupActionResponse:
+    try:
+        status = _manager(request).start()
+    except PreFormSetupError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _action_response(status, "PreFormServer start requested.")
+
+
+@router.post("/stop", response_model=PreFormSetupActionResponse)
+async def stop(request: Request) -> PreFormSetupActionResponse:
+    try:
+        status = _manager(request).stop(ignore_missing=False)
+    except PreFormSetupError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _action_response(status, "PreFormServer stop requested.")
+
+
+@router.post("/restart", response_model=PreFormSetupActionResponse)
+async def restart(request: Request) -> PreFormSetupActionResponse:
+    try:
+        status = _manager(request).restart()
+    except PreFormSetupError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _action_response(status, "PreFormServer restart requested.")
+
+
+@router.post("/recheck", response_model=PreFormSetupActionResponse)
+async def recheck(request: Request) -> PreFormSetupActionResponse:
+    status = _manager(request).recheck()
+    return _action_response(status, "PreFormServer readiness refreshed.")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -59,6 +59,34 @@ class QueueSnapshotResponse(BaseModel):
     processed_rows: list[ClassificationRow]
 
 
+PreFormReadiness = Literal[
+    "not_installed",
+    "installed_not_running",
+    "incompatible_version",
+    "ready",
+    "failed",
+]
+
+
+class PreFormSetupStatus(BaseModel):
+    readiness: PreFormReadiness
+    install_path: str
+    managed_executable_path: str
+    detected_version: str | None = None
+    expected_version_min: str
+    expected_version_max: str | None = None
+    active_configured_source: bool = True
+    is_running: bool = False
+    last_health_check_at: str | None = None
+    last_error_code: str | None = None
+    last_error_message: str | None = None
+
+
+class PreFormSetupActionResponse(BaseModel):
+    status: PreFormSetupStatus
+    message: str
+
+
 class UpdateClassificationRowRequest(BaseModel):
     model_type: Phase0ModelType | None = None
     preset: str | None = None

--- a/app/services/preform_client.py
+++ b/app/services/preform_client.py
@@ -17,6 +17,14 @@ from typing import Any, Dict, List
 import requests
 
 
+DEFAULT_SCENE_SETTINGS = {
+    "layer_thickness_mm": 0.1,
+    "machine_type": "FORM-4-0",
+    "material_code": "FLPMBE01",
+    "print_setting": "DEFAULT",
+}
+
+
 def retry_on_failure(max_retries: int = 3, backoff_factor: float = 2.0):
     """Decorator to retry API calls on failure with exponential backoff.
     
@@ -63,11 +71,11 @@ class PreFormClient:
     
     @retry_on_failure(max_retries=3, backoff_factor=2.0)
     def create_scene(self, patient_id: str, case_name: str) -> Dict[str, Any]:
-        """Create a new dental scene for a patient case.
+        """Create a new dental scene using the current Local API contract.
         
         Args:
-            patient_id: Unique identifier for the patient
-            case_name: Name/description of the dental case
+            patient_id: Retained for compatibility with older callers.
+            case_name: Retained for compatibility with older callers.
             
         Returns:
             Dict containing scene_id and status from the server
@@ -76,10 +84,7 @@ class PreFormClient:
             Exception: If the API request fails
         """
         url = f"{self.base_url}/scene/"
-        payload = {
-            "patient_id": patient_id,
-            "case_name": case_name
-        }
+        payload = dict(DEFAULT_SCENE_SETTINGS)
         
         try:
             response = self.session.post(url, json=payload, timeout=30)
@@ -93,7 +98,14 @@ class PreFormClient:
         elif response.status_code != 200:
             raise Exception(f"Failed to create scene: {response.status_code} - {response.text}")
         
-        return response.json()
+        payload = response.json()
+        if isinstance(payload, dict) and "scene_id" not in payload and "id" in payload:
+            payload = {
+                **payload,
+                "scene_id": payload["id"],
+            }
+
+        return payload
     
     @retry_on_failure(max_retries=3, backoff_factor=2.0)
     def import_model(self, scene_id: str, stl_path: str, preset: str | None = None) -> Dict[str, Any]:
@@ -113,10 +125,10 @@ class PreFormClient:
         url = f"{self.base_url}/scene/{scene_id}/import-model"
         
         try:
-            with open(stl_path, 'rb') as f:
-                files = {'model': f}
-                data = {'preset': preset} if preset else None
-                response = self.session.post(url, files=files, data=data, timeout=60)
+            payload = {'file': stl_path}
+            if preset:
+                payload['preset'] = preset
+            response = self.session.post(url, json=payload, timeout=60)
         except requests.RequestException as e:
             raise Exception(f"Failed to connect to PreFormServer: {str(e)}. Please ensure PreFormServer is running.")
         except FileNotFoundError:
@@ -149,17 +161,46 @@ class PreFormClient:
     @retry_on_failure(max_retries=3, backoff_factor=2.0)
     def validate_scene(self, scene_id: str) -> Dict[str, Any]:
         """Validate a scene and return validity state and reported issues."""
-        url = f"{self.base_url}/scene/{scene_id}/validate/"
+        url = f"{self.base_url}/scene/{scene_id}/print-validation"
 
         response = self.session.get(url, timeout=30)
 
         if response.status_code != 200:
             raise Exception(f"Failed to validate scene: {response.status_code} - {response.text}")
 
-        return response.json()
+        payload = response.json()
+        if isinstance(payload, dict) and "valid" in payload and "errors" in payload:
+            return payload
+
+        per_model_results = (
+            payload.get("per_model_results", {})
+            if isinstance(payload, dict)
+            else {}
+        )
+        errors: list[str] = []
+        for model_id, result in per_model_results.items():
+            if not isinstance(result, dict):
+                continue
+            if result.get("undersupported"):
+                errors.append(f"{model_id}: undersupported")
+            unsupported_minima = result.get("unsupported_minima", 0)
+            if isinstance(unsupported_minima, (int, float)) and unsupported_minima:
+                errors.append(f"{model_id}: unsupported minima {unsupported_minima}")
+            cups = result.get("cups", 0)
+            if isinstance(cups, (int, float)) and cups:
+                errors.append(f"{model_id}: cups {cups}")
+            if result.get("has_seamline"):
+                errors.append(f"{model_id}: seamline detected")
+
+        return {"valid": len(errors) == 0, "errors": errors}
     
     @retry_on_failure(max_retries=3, backoff_factor=2.0)
-    def send_to_printer(self, scene_id: str, device_id: str) -> Dict[str, Any]:
+    def send_to_printer(
+        self,
+        scene_id: str,
+        device_id: str,
+        job_name: str | None = None,
+    ) -> Dict[str, Any]:
         """Send a scene to a printer for production.
         
         Args:
@@ -172,10 +213,10 @@ class PreFormClient:
         Raises:
             Exception: If the API request fails
         """
-        url = f"{self.base_url}/print/"
+        url = f"{self.base_url}/scene/{scene_id}/print/"
         payload = {
-            "scene_id": scene_id,
-            "device_id": device_id
+            "job_name": job_name or scene_id,
+            "printer": device_id,
         }
         
         try:
@@ -192,7 +233,13 @@ class PreFormClient:
         elif response.status_code != 200:
             raise Exception(f"Failed to send to printer: {response.status_code} - {response.text}")
         
-        return response.json()
+        payload = response.json()
+        if isinstance(payload, dict) and "print_id" not in payload and "job_id" in payload:
+            payload = {
+                **payload,
+                "print_id": payload["job_id"],
+            }
+        return payload
     
     def list_devices(self) -> List[Dict[str, Any]]:
         """List all available printer devices.

--- a/app/services/preform_setup_service.py
+++ b/app/services/preform_setup_service.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import signal
+import subprocess
+import time
+import zipfile
+from pathlib import Path
+from uuid import uuid4
+
+import requests
+
+from ..config import Settings
+from ..database import load_preform_setup_state, save_preform_setup_state
+from ..schemas import PreFormSetupStatus
+
+
+class PreFormSetupError(RuntimeError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def get_preform_setup_status(settings: Settings) -> PreFormSetupStatus:
+    return PreFormSetupService(settings).recheck()
+
+
+class PreFormSetupService:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    def install_from_zip(self, archive_path: Path) -> PreFormSetupStatus:
+        self._validate_zip(archive_path)
+        staging_root = self._extract_to_staging(archive_path)
+        try:
+            payload_root = self._resolve_payload_root(staging_root)
+            self.stop(ignore_missing=True)
+            self._replace_managed_install(payload_root)
+        finally:
+            shutil.rmtree(staging_root, ignore_errors=True)
+        return self.start()
+
+    def replace_from_zip(self, archive_path: Path) -> PreFormSetupStatus:
+        return self.install_from_zip(archive_path)
+
+    def start(self) -> PreFormSetupStatus:
+        executable = self.settings.preform_managed_executable
+        if not executable.exists():
+            raise PreFormSetupError(
+                "missing_install",
+                "Managed PreFormServer install is missing.",
+            )
+
+        pid = self._launch_process(executable)
+        return self._wait_for_server(pid)
+
+    def stop(self, *, ignore_missing: bool = False) -> PreFormSetupStatus:
+        state = load_preform_setup_state(self.settings)
+        pid = state.get("process_id")
+        if pid:
+            try:
+                self._terminate_process(int(pid))
+            except Exception as exc:
+                if not ignore_missing:
+                    raise PreFormSetupError(
+                        "stop_failed",
+                        f"Could not stop managed PreFormServer process {pid}: {exc}",
+                    ) from exc
+
+        readiness = (
+            "installed_not_running"
+            if self.settings.preform_managed_executable.exists()
+            else "not_installed"
+        )
+        return self._persist_status(
+            readiness=readiness,
+            detected_version=state.get("detected_version"),
+            process_id=None,
+            is_running=False,
+            error_code=None,
+            error_message=None,
+        )
+
+    def restart(self) -> PreFormSetupStatus:
+        self.stop(ignore_missing=True)
+        return self.start()
+
+    def recheck(self) -> PreFormSetupStatus:
+        state = load_preform_setup_state(self.settings)
+        executable = self.settings.preform_managed_executable
+        if not executable.exists():
+            return self._persist_status(
+                readiness="not_installed",
+                detected_version=None,
+                process_id=None,
+                is_running=False,
+                error_code=None,
+                error_message=None,
+            )
+
+        probe = self._probe_server()
+        if not probe["healthy"]:
+            return self._persist_status(
+                readiness="installed_not_running",
+                detected_version=None,
+                process_id=state.get("process_id"),
+                is_running=False,
+                error_code=str(probe["code"]),
+                error_message=str(probe["message"]),
+            )
+
+        version = str(probe["version"])
+        if not self._version_is_supported(version):
+            return self._persist_status(
+                readiness="incompatible_version",
+                detected_version=version,
+                process_id=state.get("process_id"),
+                is_running=True,
+                error_code="incompatible_version",
+                error_message=(
+                    f"Detected PreFormServer {version} is outside the supported version contract."
+                ),
+            )
+
+        return self._persist_status(
+            readiness="ready",
+            detected_version=version,
+            process_id=state.get("process_id"),
+            is_running=True,
+            error_code=None,
+            error_message=None,
+        )
+
+    def _wait_for_server(self, pid: int) -> PreFormSetupStatus:
+        deadline = time.monotonic() + self.settings.preform_server_startup_timeout_s
+        last_probe = {
+            "healthy": False,
+            "version": None,
+            "code": "start_failed",
+            "message": "Timed out waiting for PreFormServer to become healthy.",
+        }
+
+        while time.monotonic() < deadline:
+            probe = self._probe_server()
+            if probe["healthy"]:
+                version = str(probe["version"])
+                if not self._version_is_supported(version):
+                    return self._persist_status(
+                        readiness="incompatible_version",
+                        detected_version=version,
+                        process_id=pid,
+                        is_running=True,
+                        error_code="incompatible_version",
+                        error_message=(
+                            f"Detected PreFormServer {version} is outside the supported version contract."
+                        ),
+                    )
+                return self._persist_status(
+                    readiness="ready",
+                    detected_version=version,
+                    process_id=pid,
+                    is_running=True,
+                    error_code=None,
+                    error_message=None,
+                )
+            last_probe = probe
+            time.sleep(1)
+
+        return self._persist_status(
+            readiness="installed_not_running",
+            detected_version=None,
+            process_id=pid,
+            is_running=False,
+            error_code=str(last_probe["code"]),
+            error_message=str(last_probe["message"]),
+        )
+
+    def _persist_status(
+        self,
+        *,
+        readiness: str,
+        detected_version: str | None,
+        process_id: int | None,
+        is_running: bool,
+        error_code: str | None,
+        error_message: str | None,
+    ) -> PreFormSetupStatus:
+        state = save_preform_setup_state(
+            self.settings,
+            readiness=readiness,
+            install_path=str(self.settings.preform_managed_dir),
+            managed_executable_path=str(self.settings.preform_managed_executable),
+            detected_version=detected_version,
+            last_health_check_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            last_error_code=error_code,
+            last_error_message=error_message,
+            active_configured_source=True,
+            process_id=process_id,
+        )
+        return PreFormSetupStatus(
+            readiness=str(state["readiness"]),
+            install_path=str(state["install_path"]),
+            managed_executable_path=str(state["managed_executable_path"]),
+            detected_version=(
+                str(state["detected_version"])
+                if state["detected_version"] is not None
+                else None
+            ),
+            expected_version_min=self.settings.preform_min_supported_version,
+            expected_version_max=self.settings.preform_max_supported_version,
+            active_configured_source=bool(state["active_configured_source"]),
+            is_running=is_running,
+            last_health_check_at=(
+                str(state["last_health_check_at"])
+                if state["last_health_check_at"] is not None
+                else None
+            ),
+            last_error_code=(
+                str(state["last_error_code"])
+                if state["last_error_code"] is not None
+                else None
+            ),
+            last_error_message=(
+                str(state["last_error_message"])
+                if state["last_error_message"] is not None
+                else None
+            ),
+        )
+
+    def _validate_zip(self, archive_path: Path) -> None:
+        if not archive_path.exists():
+            raise PreFormSetupError("bad_zip", "Selected ZIP file does not exist.")
+        if archive_path.suffix.lower() != ".zip":
+            raise PreFormSetupError("bad_zip", "Select a .zip package for PreFormServer.")
+        if archive_path.stat().st_size < self.settings.preform_min_zip_size_bytes:
+            raise PreFormSetupError(
+                "bad_zip",
+                "Selected ZIP is smaller than the minimum supported package size.",
+            )
+
+        try:
+            with zipfile.ZipFile(archive_path) as archive:
+                members = [
+                    Path(member.filename)
+                    for member in archive.infolist()
+                    if not member.is_dir()
+                ]
+        except zipfile.BadZipFile as exc:
+            raise PreFormSetupError("bad_zip", "Selected ZIP archive is corrupt.") from exc
+
+        if not members:
+            raise PreFormSetupError("bad_zip", "Selected ZIP archive is empty.")
+
+        for member in members:
+            if member.is_absolute() or ".." in member.parts:
+                raise PreFormSetupError(
+                    "bad_zip",
+                    "Selected ZIP uses an unsupported package shape.",
+                )
+
+        if "PreFormServer.exe" not in {member.name for member in members}:
+            raise PreFormSetupError(
+                "bad_zip",
+                "ZIP does not contain a supported PreFormServer.exe payload.",
+            )
+
+    def _extract_to_staging(self, archive_path: Path) -> Path:
+        staging_root = (
+            self.settings.preform_managed_dir.parent / f".preform-staging-{uuid4().hex}"
+        )
+        staging_root.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(staging_root)
+        return staging_root
+
+    def _resolve_payload_root(self, staging_root: Path) -> Path:
+        candidates = list(staging_root.rglob("PreFormServer.exe"))
+        if not candidates:
+            raise PreFormSetupError(
+                "bad_zip",
+                "Staged package does not contain PreFormServer.exe.",
+            )
+        if len(candidates) > 1:
+            raise PreFormSetupError(
+                "bad_zip",
+                "ZIP contains multiple PreFormServer.exe candidates.",
+            )
+
+        executable_path = candidates[0]
+        relative_parts = executable_path.relative_to(staging_root).parts
+        if len(relative_parts) == 1:
+            return staging_root
+        if len(relative_parts) == 2:
+            return staging_root / relative_parts[0]
+        raise PreFormSetupError(
+            "bad_zip",
+            "ZIP uses an unsupported nested package layout.",
+        )
+
+    def _replace_managed_install(self, payload_root: Path) -> None:
+        managed_dir = self.settings.preform_managed_dir
+        managed_dir.parent.mkdir(parents=True, exist_ok=True)
+        backup_dir = managed_dir.parent / f".preform-backup-{uuid4().hex}"
+
+        if managed_dir.exists():
+            managed_dir.rename(backup_dir)
+
+        try:
+            payload_root.rename(managed_dir)
+        except Exception as exc:
+            if backup_dir.exists() and not managed_dir.exists():
+                backup_dir.rename(managed_dir)
+            raise PreFormSetupError(
+                "install_failed",
+                f"Could not replace the managed PreFormServer install: {exc}",
+            ) from exc
+        finally:
+            shutil.rmtree(backup_dir, ignore_errors=True)
+
+    def _launch_process(self, executable_path: Path) -> int:
+        args = [
+            str(executable_path),
+            "--port",
+            str(self.settings.preform_server_port),
+        ]
+        creation_flags = 0
+        if os.name == "nt":
+            creation_flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
+                subprocess,
+                "CREATE_NEW_PROCESS_GROUP",
+                0,
+            )
+
+        process = subprocess.Popen(
+            args,
+            cwd=str(self.settings.preform_managed_dir),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=creation_flags,
+        )
+        return int(process.pid)
+
+    def _terminate_process(self, pid: int) -> None:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            return
+        os.kill(pid, signal.SIGTERM)
+
+    def _probe_server(self) -> dict[str, object]:
+        session = requests.Session()
+        version = self._read_managed_version_file()
+        for endpoint in ("", "/", "/health", "/health/ready"):
+            url = f"{self.settings.preform_server_url.rstrip('/')}{endpoint}"
+            try:
+                response = session.get(url, timeout=5)
+            except requests.RequestException as exc:
+                last_error = {
+                    "healthy": False,
+                    "version": None,
+                    "code": "health_check_failed",
+                    "message": str(exc),
+                }
+                continue
+
+            if response.status_code >= 500:
+                last_error = {
+                    "healthy": False,
+                    "version": None,
+                    "code": "health_check_failed",
+                    "message": f"Server returned {response.status_code}.",
+                }
+                continue
+
+            payload = self._load_response_payload(response)
+            detected_version = self._extract_version(payload) or version
+            if detected_version is None:
+                detected_version = "0.0.0"
+            session.close()
+            return {
+                "healthy": response.ok or response.status_code < 500,
+                "version": detected_version,
+                "code": None,
+                "message": None,
+            }
+
+        session.close()
+        return last_error
+
+    def _read_managed_version_file(self) -> str | None:
+        version_file = self.settings.preform_managed_dir / "version.txt"
+        if version_file.exists():
+            return version_file.read_text(encoding="utf-8").strip() or None
+        return None
+
+    def _load_response_payload(self, response: requests.Response) -> object:
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    def _extract_version(self, payload: object) -> str | None:
+        if isinstance(payload, dict):
+            for key in (
+                "version",
+                "build_version",
+                "preform_version",
+                "server_version",
+            ):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            for value in payload.values():
+                detected = self._extract_version(value)
+                if detected:
+                    return detected
+            return None
+
+        if isinstance(payload, list):
+            for item in payload:
+                detected = self._extract_version(item)
+                if detected:
+                    return detected
+            return None
+
+        if isinstance(payload, str):
+            match = re.search(r"\d+\.\d+\.\d+(?:\.\d+)?", payload)
+            return match.group(0) if match else None
+
+        return None
+
+    def _version_is_supported(self, version: str) -> bool:
+        version_tuple = self._version_tuple(version)
+        if version_tuple < self._version_tuple(self.settings.preform_min_supported_version):
+            return False
+        if self.settings.preform_max_supported_version and version_tuple > self._version_tuple(
+            self.settings.preform_max_supported_version
+        ):
+            return False
+        return True
+
+    def _version_tuple(self, value: str) -> tuple[int, ...]:
+        numbers = [int(part) for part in re.findall(r"\d+", value)]
+        if not numbers:
+            return (0,)
+        return tuple(numbers)

--- a/app/services/print_queue_service.py
+++ b/app/services/print_queue_service.py
@@ -289,6 +289,16 @@ def _validation_errors(validation_result: dict[str, Any]) -> list[str]:
     return [str(error) for error in errors]
 
 
+def assert_preform_ready(settings: "Settings") -> None:
+    from .preform_setup_service import get_preform_setup_status
+
+    status = get_preform_setup_status(settings)
+    if status.readiness != "ready":
+        raise ValueError(
+            f"PreFormServer setup is required before printing ({status.readiness})."
+        )
+
+
 def process_print_manifest(
     settings: "Settings",
     manifest: "BuildManifest",
@@ -389,6 +399,8 @@ def send_ready_rows_to_print(
 
     if not row_ids:
         return []
+
+    assert_preform_ready(settings)
 
     rows = []
     for row_id in row_ids:

--- a/app/services/print_queue_service.py
+++ b/app/services/print_queue_service.py
@@ -182,7 +182,7 @@ def generate_job_name(date: datetime, batch_number: int) -> str:
 def _resolve_device_id(rows: list["ClassificationRow"]) -> str:
     explicit_printers = {row.printer for row in rows if row.printer}
     if not explicit_printers:
-        return "default"
+        return "Form 4"
     if len(explicit_printers) > 1:
         raise ValueError("Rows in the same print batch target different printers.")
     return next(iter(explicit_printers))
@@ -348,7 +348,11 @@ def process_print_manifest(
         client.auto_layout(scene_id)
         validation_result = client.validate_scene(scene_id)
         if validation_result.get("valid", False):
-            print_result = client.send_to_printer(scene_id, _resolve_device_id(active_rows))
+            print_result = client.send_to_printer(
+                scene_id,
+                _resolve_device_id(active_rows),
+                job_name=job_name,
+            )
             return {
                 "job_name": job_name,
                 "scene_id": scene_id,

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -6,6 +6,16 @@ const MODEL_TYPES = [
     "Splint",
 ];
 
+const DEFAULT_PRESET_BY_MODEL = {
+    "Ortho - Solid": "Ortho Solid - Flat, No Supports",
+    "Ortho - Hollow": "Ortho Hollow - Flat, No Supports",
+    Die: "Die - Flat, No Supports",
+    Tooth: "Tooth - With Supports",
+    Splint: "Splint - Flat, No Supports",
+};
+
+const PRESET_OPTIONS = Object.values(DEFAULT_PRESET_BY_MODEL);
+
 const ACTIVE_STATUSES = [
     "Queued",
     "Uploading",
@@ -49,6 +59,11 @@ const state = {
         page: 1,
         expandedCases: new Set(),
     },
+    preformSetup: {
+        status: null,
+        loading: false,
+        wizardDismissed: false,
+    },
 };
 
 const elements = {
@@ -68,6 +83,21 @@ const elements = {
     previewModal: document.getElementById("preview-modal"),
     previewTitle: document.getElementById("preview-title"),
     previewViewer: document.getElementById("preview-viewer"),
+    preformBanner: document.getElementById("preform-banner"),
+    preformInstallButton: document.getElementById("preform-install-button"),
+    preformInstallPath: document.getElementById("preform-install-path"),
+    preformLastCheck: document.getElementById("preform-last-check"),
+    preformReadinessPill: document.getElementById("preform-readiness-pill"),
+    preformRecheckButton: document.getElementById("preform-recheck-button"),
+    preformRestartButton: document.getElementById("preform-restart-button"),
+    preformSetupPanel: document.getElementById("preform-setup-panel"),
+    preformStartButton: document.getElementById("preform-start-button"),
+    preformStopButton: document.getElementById("preform-stop-button"),
+    preformSummary: document.getElementById("preform-summary"),
+    preformVersion: document.getElementById("preform-version"),
+    preformVersionRange: document.getElementById("preform-version-range"),
+    preformWizard: document.getElementById("preform-wizard"),
+    preformZipInput: document.getElementById("preform-zip-input"),
     processedBody: document.getElementById("processed-body"),
     processedCount: document.getElementById("processed-count"),
     processedPanel: document.getElementById("processed-panel"),
@@ -113,12 +143,189 @@ function setStatus(message, isError = false) {
     elements.statusText.classList.toggle("error-text", isError);
 }
 
+function getPreformSetupStatus() {
+    return state.preformSetup.status;
+}
+
+function canPrint() {
+    return getPreformSetupStatus()?.readiness === "ready";
+}
+
+function formatPreformRange(status) {
+    if (!status) {
+        return "-";
+    }
+    return status.expected_version_max
+        ? `${status.expected_version_min} to ${status.expected_version_max}`
+        : `${status.expected_version_min}+`;
+}
+
+function preformReadinessLabel(status) {
+    if (!status) {
+        return "Checking";
+    }
+    switch (status.readiness) {
+        case "ready":
+            return "Ready";
+        case "not_installed":
+            return "Not Installed";
+        case "installed_not_running":
+            return "Stopped";
+        case "incompatible_version":
+            return "Update Required";
+        default:
+            return "Needs Attention";
+    }
+}
+
+function preformReadinessTone(status) {
+    if (!status) {
+        return "neutral";
+    }
+    switch (status.readiness) {
+        case "ready":
+            return "ready";
+        case "incompatible_version":
+            return "warn";
+        case "not_installed":
+        case "installed_not_running":
+            return "info";
+        default:
+            return "danger";
+    }
+}
+
+function describePreformSetup(status) {
+    if (!status) {
+        return "Checking managed PreFormServer readiness.";
+    }
+    switch (status.readiness) {
+        case "ready":
+            return `Managed PreFormServer is healthy and ready for print handoff on the configured local port.`;
+        case "not_installed":
+            return "No managed PreFormServer install exists yet. Select a local ZIP package to install the canonical copy used by Andent Web.";
+        case "installed_not_running":
+            return status.last_error_message
+                ? `A managed install exists, but the local API is not reachable. ${status.last_error_message}`
+                : "A managed install exists, but the local API is not reachable. Start the managed service or replace it with a newer ZIP.";
+        case "incompatible_version":
+            return status.last_error_message
+                ? status.last_error_message
+                : "The managed PreFormServer version is outside the supported range. Replace it with a compatible ZIP before printing.";
+        default:
+            return status.last_error_message || "PreFormServer needs attention before print handoff can continue.";
+    }
+}
+
+function openPreformWizard() {
+    state.preformSetup.wizardDismissed = false;
+    renderPreformWizard();
+}
+
+function dismissPreformWizard() {
+    state.preformSetup.wizardDismissed = true;
+    renderPreformWizard();
+}
+
+async function fetchPreformSetupStatus() {
+    const response = await fetch("/api/preform-setup/status");
+    const payload = await response.json();
+    if (!response.ok) {
+        throw new Error(payload.detail || "Could not load PreFormServer setup status.");
+    }
+    state.preformSetup.status = payload;
+}
+
+async function runPreformAction(url, options, successMessage) {
+    state.preformSetup.loading = true;
+    renderPreformSetup();
+    try {
+        const response = await fetch(url, options);
+        const payload = await response.json();
+        if (!response.ok) {
+            throw new Error(payload.detail || payload.message || "PreFormServer action failed.");
+        }
+        state.preformSetup.status = payload.status;
+        setStatus(payload.message || successMessage);
+    } catch (error) {
+        setStatus(error.message, true);
+    } finally {
+        state.preformSetup.loading = false;
+        render();
+    }
+}
+
+function renderPreformSetup() {
+    const status = getPreformSetupStatus();
+    const tone = preformReadinessTone(status);
+    const label = preformReadinessLabel(status);
+    const summary = describePreformSetup(status);
+    const blocked = status && status.readiness !== "ready";
+
+    elements.preformReadinessPill.textContent = label;
+    elements.preformReadinessPill.className = `status-pill status-pill-${tone}`;
+    elements.preformSummary.textContent = summary;
+    elements.preformInstallPath.textContent = status?.install_path || "-";
+    elements.preformVersion.textContent = status?.detected_version || "-";
+    elements.preformVersionRange.textContent = formatPreformRange(status);
+    elements.preformLastCheck.textContent = formatDate(status?.last_health_check_at || "");
+    elements.preformBanner.classList.toggle("hidden", !blocked);
+    elements.preformBanner.textContent = blocked
+        ? `Print handoff is blocked until PreFormServer is ${label.toLowerCase()}.`
+        : "";
+
+    elements.preformStartButton.disabled = state.preformSetup.loading || !status || status.readiness === "ready";
+    elements.preformStopButton.disabled = state.preformSetup.loading || !status || status.readiness === "not_installed";
+    elements.preformRestartButton.disabled = state.preformSetup.loading || !status || status.readiness === "not_installed";
+    elements.preformRecheckButton.disabled = state.preformSetup.loading || !status;
+    elements.preformInstallButton.disabled = state.preformSetup.loading;
+    renderPreformWizard();
+}
+
+function renderPreformWizard() {
+    const status = getPreformSetupStatus();
+    const shouldShow = status && status.readiness !== "ready" && !state.preformSetup.wizardDismissed;
+    elements.preformWizard.classList.toggle("hidden", !shouldShow);
+    elements.preformWizard.setAttribute("aria-hidden", String(!shouldShow));
+    if (!shouldShow) {
+        elements.preformWizard.innerHTML = "";
+        return;
+    }
+
+    elements.preformWizard.innerHTML = `
+        <div class="wizard-backdrop" data-close-modal="wizard"></div>
+        <div class="wizard-card" role="dialog" aria-modal="true" aria-labelledby="preform-wizard-title">
+            <div class="wizard-header">
+                <div>
+                    <p class="eyebrow">PreFormServer Setup</p>
+                    <h2 id="preform-wizard-title">${preformReadinessLabel(status)}</h2>
+                </div>
+                <button type="button" class="ghost-button" data-wizard-dismiss="true">Continue Without Printing</button>
+            </div>
+            <p class="setup-summary">${describePreformSetup(status)}</p>
+            <div class="wizard-checklist">
+                <div class="wizard-checklist-item">Managed install path: ${status.install_path}</div>
+                <div class="wizard-checklist-item">Supported range: ${formatPreformRange(status)}</div>
+                <div class="wizard-checklist-item">Detected version: ${status.detected_version || "-"}</div>
+            </div>
+            <div class="wizard-actions">
+                <button type="button" class="primary-button" data-preform-install="true">Select ZIP Package</button>
+                <button type="button" class="secondary-button" data-preform-recheck="true">Re-check</button>
+            </div>
+        </div>
+    `;
+}
+
 function releasePickerGuard() {
     state.pickerOpen = false;
     if (state.pickerReleaseId) {
         window.clearTimeout(state.pickerReleaseId);
         state.pickerReleaseId = null;
     }
+}
+
+function getDefaultPreset(modelType) {
+    return DEFAULT_PRESET_BY_MODEL[modelType] || "";
 }
 
 function schedulePickerGuardRelease(delay = 200) {
@@ -150,10 +357,11 @@ function openPicker(input) {
 }
 
 function normalizeRow(row) {
+    const defaultPreset = getDefaultPreset(row.model_type);
     return {
         ...row,
         row_id: row.row_id,
-        preset_overridden: Boolean(row.preset && row.model_type && row.preset !== row.model_type),
+        preset_overridden: Boolean(row.preset && defaultPreset && row.preset !== defaultPreset),
         is_temp: false,
     };
 }
@@ -442,6 +650,7 @@ async function persistRow(row) {
 
 function createModelTypeSelect(row) {
     const select = document.createElement("select");
+    select.dataset.testid = "model-type-select";
     const placeholder = document.createElement("option");
     placeholder.value = "";
     placeholder.textContent = "Select";
@@ -471,9 +680,13 @@ function createModelTypeSelect(row) {
     select.addEventListener("change", (event) => {
         row.model_type = event.target.value || null;
         if (!row.preset_overridden) {
-            row.preset = event.target.value || "";
+            row.preset = getDefaultPreset(row.model_type);
         }
-        row.preset_overridden = Boolean(row.preset && row.model_type && row.preset !== row.model_type);
+        row.preset_overridden = Boolean(
+            row.preset &&
+            row.model_type &&
+            row.preset !== getDefaultPreset(row.model_type)
+        );
         render();
         persistRow(row);
     });
@@ -482,6 +695,7 @@ function createModelTypeSelect(row) {
 
 function createPresetSelect(row) {
     const select = document.createElement("select");
+    select.dataset.testid = "preset-select";
     const placeholder = document.createElement("option");
     placeholder.value = "";
     placeholder.textContent = "Select";
@@ -489,7 +703,7 @@ function createPresetSelect(row) {
     placeholder.selected = !row.preset;
     select.appendChild(placeholder);
 
-    MODEL_TYPES.forEach((optionValue) => {
+    PRESET_OPTIONS.forEach((optionValue) => {
         const option = document.createElement("option");
         option.value = optionValue;
         option.textContent = optionValue;
@@ -510,7 +724,11 @@ function createPresetSelect(row) {
     });
     select.addEventListener("change", (event) => {
         row.preset = event.target.value || "";
-        row.preset_overridden = Boolean(row.preset && row.model_type && row.preset !== row.model_type);
+        row.preset_overridden = Boolean(
+            row.preset &&
+            row.model_type &&
+            row.preset !== getDefaultPreset(row.model_type)
+        );
         render();
         persistRow(row);
     });
@@ -636,6 +854,12 @@ function renderActiveRows() {
 
     pageRows.forEach((row) => {
         const tr = document.createElement("tr");
+        if (!row.is_temp) {
+            tr.dataset.rowId = String(row.row_id ?? "");
+            tr.dataset.fileName = row.file_name;
+            tr.dataset.caseId = row.case_id || "";
+            tr.dataset.rowStatus = getRowStatus(row);
+        }
         if (isRowPendingDelete(row)) {
             tr.classList.add("row-pending-delete");
         }
@@ -643,6 +867,7 @@ function renderActiveRows() {
         const selectCell = document.createElement("td");
         const checkbox = document.createElement("input");
         checkbox.type = "checkbox";
+        checkbox.dataset.testid = "row-select";
         checkbox.checked = !row.is_temp && state.selectedIds.has(row.row_id);
         checkbox.disabled = !isEditableActiveRow(row);
         checkbox.addEventListener("change", (event) => toggleRowSelection(row, event.target.checked));
@@ -673,7 +898,9 @@ function renderActiveRows() {
         tr.appendChild(presetCell);
 
         const statusCell = document.createElement("td");
-        statusCell.appendChild(createChip(getRowStatus(row)));
+        const chip = createChip(getRowStatus(row));
+        chip.dataset.testid = "status-chip";
+        statusCell.appendChild(chip);
         tr.appendChild(statusCell);
 
         const dimensionsCell = document.createElement("td");
@@ -1094,9 +1321,17 @@ function renderBulkActions() {
     if (readyRows.length > 0) {
         const submitButton = document.createElement("button");
         submitButton.type = "button";
-        submitButton.className = "primary-button";
-        submitButton.textContent = `Send to Print (${readyRows.length})`;
+        submitButton.dataset.testid = "send-to-print-button";
+        submitButton.className = canPrint() ? "primary-button" : "secondary-button";
+        submitButton.textContent = canPrint()
+            ? `Send to Print (${readyRows.length})`
+            : `Setup Required (${readyRows.length})`;
         submitButton.addEventListener("click", async () => {
+            if (!canPrint()) {
+                openPreformWizard();
+                setStatus("Complete PreFormServer setup before sending rows to print.", true);
+                return;
+            }
             try {
                 const response = await fetch("/api/uploads/rows/send-to-print", {
                     method: "POST",
@@ -1182,6 +1417,7 @@ function renderTabs() {
 function render() {
     clampPages();
     syncSelection();
+    renderPreformSetup();
     renderTabs();
     renderLegend();
     renderBulkActions();
@@ -1207,6 +1443,9 @@ function render() {
         state.printQueue.page = page;
     });
     elements.queueActionButton.textContent = "Select Folder";
+    elements.printQueueEmpty.textContent = canPrint()
+        ? "No print jobs in queue."
+        : "Print queue unavailable until PreFormServer setup is ready.";
 }
 
 function createPendingRow(file) {
@@ -1640,6 +1879,56 @@ elements.screenshotModal.addEventListener("click", (event) => {
 
 elements.closeScreenshot.addEventListener("click", closeScreenshotModal);
 
+elements.preformInstallButton.addEventListener("click", () => {
+    openPicker(elements.preformZipInput);
+});
+
+elements.preformZipInput.addEventListener("change", async (event) => {
+    const [file] = Array.from(event.target.files || []);
+    event.target.value = "";
+    releasePickerGuard();
+    if (!file) {
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append("package", file, file.name);
+    await runPreformAction("/api/preform-setup/install-from-zip", {
+        method: "POST",
+        body: formData,
+    }, "PreFormServer installed.");
+});
+
+elements.preformStartButton.addEventListener("click", async () => {
+    await runPreformAction("/api/preform-setup/start", { method: "POST" }, "PreFormServer start requested.");
+});
+
+elements.preformStopButton.addEventListener("click", async () => {
+    await runPreformAction("/api/preform-setup/stop", { method: "POST" }, "PreFormServer stop requested.");
+});
+
+elements.preformRestartButton.addEventListener("click", async () => {
+    await runPreformAction("/api/preform-setup/restart", { method: "POST" }, "PreFormServer restart requested.");
+});
+
+elements.preformRecheckButton.addEventListener("click", async () => {
+    await runPreformAction("/api/preform-setup/recheck", { method: "POST" }, "PreFormServer readiness refreshed.");
+});
+
+elements.preformWizard.addEventListener("click", (event) => {
+    if (event.target.dataset.closeModal === "wizard" || event.target.dataset.wizardDismiss === "true") {
+        dismissPreformWizard();
+        return;
+    }
+    if (event.target.dataset.preformInstall === "true") {
+        openPicker(elements.preformZipInput);
+        return;
+    }
+    if (event.target.dataset.preformRecheck === "true") {
+        runPreformAction("/api/preform-setup/recheck", { method: "POST" }, "PreFormServer readiness refreshed.");
+    }
+});
+
 
 // Queue polling - auto-refresh every 10 seconds
 window.pollingPaused = false;
@@ -1649,6 +1938,7 @@ window.setInterval(async () => {
     if (window.pollingPaused) return;
     try {
         await fetchQueue();
+        await fetchPreformSetupStatus();
         render();
         console.log("Queue auto-refreshed");
     } catch (error) {
@@ -1690,8 +1980,13 @@ async function bootstrap() {
     try {
         await fetchQueue();
         await fetchPrintQueue();
+        await fetchPreformSetupStatus();
         render();
-        setStatus("Queue loaded.");
+        if (canPrint()) {
+            setStatus("Queue loaded.");
+        } else {
+            setStatus("Queue loaded. Complete PreFormServer setup before printing.", true);
+        }
     } catch (error) {
         setStatus(error.message, true);
         render();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -24,8 +24,49 @@
             <h1>Active Queue</h1>
             <p class="lede">
                 Drop STL files or folders, review anything that needs attention, then move
-                ready items into the simulated print handoff without leaving the queue.
+                ready items into the managed PreFormServer handoff without leaving the queue.
             </p>
+        </section>
+
+        <section id="preform-banner" class="panel setup-banner hidden"></section>
+
+        <section id="preform-setup-panel" class="panel setup-panel">
+            <div class="setup-panel-header">
+                <div>
+                    <p class="eyebrow">PreFormServer</p>
+                    <h2>Setup Center</h2>
+                </div>
+                <span id="preform-readiness-pill" class="status-pill status-pill-neutral">Checking...</span>
+            </div>
+            <p id="preform-summary" class="setup-summary">
+                Checking managed PreFormServer readiness.
+            </p>
+            <div class="setup-meta-grid">
+                <div class="setup-meta-item">
+                    <span>Install Path</span>
+                    <strong id="preform-install-path">-</strong>
+                </div>
+                <div class="setup-meta-item">
+                    <span>Detected Version</span>
+                    <strong id="preform-version">-</strong>
+                </div>
+                <div class="setup-meta-item">
+                    <span>Supported Range</span>
+                    <strong id="preform-version-range">-</strong>
+                </div>
+                <div class="setup-meta-item">
+                    <span>Last Check</span>
+                    <strong id="preform-last-check">-</strong>
+                </div>
+            </div>
+            <div class="setup-actions">
+                <input id="preform-zip-input" type="file" accept=".zip" hidden>
+                <button id="preform-install-button" type="button" class="primary-button">Install or Replace ZIP</button>
+                <button id="preform-start-button" type="button" class="secondary-button">Start</button>
+                <button id="preform-stop-button" type="button" class="ghost-button">Stop</button>
+                <button id="preform-restart-button" type="button" class="secondary-button">Restart</button>
+                <button id="preform-recheck-button" type="button" class="ghost-button">Re-check</button>
+            </div>
         </section>
 
         <section class="panel uploader-panel">
@@ -163,6 +204,8 @@
             <p id="screenshot-caption" class="preview-caption"></p>
         </div>
     </div>
+
+    <div id="preform-wizard" class="wizard-shell hidden" aria-hidden="true"></div>
 
     <script src="/static/app.js"></script>
 </body>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -156,6 +156,136 @@ h2 {
     background: linear-gradient(180deg, #fff7f1 0%, #fff2ea 100%);
 }
 
+.setup-banner {
+    display: block;
+    border-color: rgba(175, 106, 0, 0.28);
+    background: linear-gradient(135deg, #fff8e8 0%, #fff2d8 100%);
+    color: var(--warn);
+    font-family: var(--font-ui);
+    font-weight: 700;
+}
+
+.setup-panel {
+    display: grid;
+    gap: 16px;
+    background:
+        radial-gradient(circle at top right, rgba(8, 100, 199, 0.08), transparent 30%),
+        linear-gradient(180deg, #ffffff 0%, #faf8f3 100%);
+}
+
+.setup-panel-header,
+.setup-actions,
+.wizard-header,
+.wizard-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.setup-summary {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.setup-meta-grid,
+.wizard-checklist {
+    display: grid;
+    gap: 12px;
+}
+
+.setup-meta-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.setup-meta-item,
+.wizard-checklist-item {
+    padding: 14px 16px;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.86);
+}
+
+.setup-meta-item span {
+    display: block;
+    margin-bottom: 8px;
+    color: var(--muted);
+    font-family: var(--font-ui);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.setup-meta-item strong {
+    display: block;
+    line-height: 1.5;
+    word-break: break-word;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 8px 12px;
+    font-family: var(--font-ui);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.status-pill-neutral {
+    background: #f2efe8;
+    color: var(--ink);
+}
+
+.status-pill-ready {
+    background: var(--clear-soft);
+    color: var(--clear);
+}
+
+.status-pill-info {
+    background: var(--info-soft);
+    color: var(--info);
+}
+
+.status-pill-warn {
+    background: var(--warn-soft);
+    color: var(--warn);
+}
+
+.status-pill-danger {
+    background: var(--danger-soft);
+    color: var(--danger);
+}
+
+.wizard-shell {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+}
+
+.wizard-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(17, 17, 16, 0.68);
+}
+
+.wizard-card {
+    position: relative;
+    z-index: 1;
+    width: min(760px, calc(100vw - 32px));
+    margin: 48px auto;
+    padding: 32px;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.32);
+    background:
+        radial-gradient(circle at top right, rgba(255, 90, 0, 0.12), transparent 32%),
+        linear-gradient(180deg, #ffffff 0%, #f8f5ee 100%);
+    box-shadow: 0 30px 90px rgba(0, 0, 0, 0.26);
+}
+
 .dropzone-title {
     margin: 0;
     font-family: var(--font-ui);

--- a/docs/superpowers/plans/2026-04-21-preformserver-setup-wizard.md
+++ b/docs/superpowers/plans/2026-04-21-preformserver-setup-wizard.md
@@ -1,0 +1,485 @@
+# PreFormServer Setup Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a managed Windows PreFormServer setup flow with ZIP install/replacement, readiness persistence, version gating, service control, and a queue UI that blocks print actions until the managed dependency is ready.
+
+**Architecture:** Add one backend manager service that owns the canonical managed install path, ZIP validation, staged extraction, process lifecycle, health/version checks, and readiness persistence. Expose that manager through dedicated API routes, then update the existing queue page to show setup state, render a first-run wizard plus maintenance panel, and intercept `Send to Print` whenever readiness is not `ready`.
+
+**Tech Stack:** FastAPI, SQLite, Pydantic, pytest, vanilla JS, Windows-managed filesystem/process flow, existing PreFormServer HTTP client
+
+---
+
+## File Structure
+
+### New Files
+
+- `app/services/preform_setup_service.py`
+  Owns managed install resolution, ZIP validation, staged extraction, replace flow, process control, health checks, version parsing, compatibility checks, and readiness persistence helpers.
+- `app/routers/preform_setup.py`
+  Owns the setup-center API surface for status, install, replace, start, stop, restart, and recheck.
+- `tests/test_preform_setup.py`
+  Owns TDD coverage for setup status, ZIP validation/install, version gating, and print blocking before readiness.
+
+### Existing Files To Modify
+
+- `app/config.py`
+  Add managed install, port, timeout, and compatibility settings.
+- `app/database.py`
+  Persist PreFormServer readiness state and last known error details.
+- `app/schemas.py`
+  Add setup-status and setup-action response models.
+- `app/main.py`
+  Register the new setup router.
+- `app/services/print_queue_service.py`
+  Enforce a hard readiness gate before live PreForm handoff.
+- `app/routers/uploads.py`
+  Return a setup-related HTTP conflict instead of raw handoff failure when readiness is blocked.
+- `app/static/index.html`
+  Add the setup banner, setup center, and first-run wizard shell.
+- `app/static/app.js`
+  Load setup status, drive ZIP upload/actions, disable or intercept print actions, and render degraded-state UI.
+- `app/static/styles.css`
+  Style the setup center, banner, wizard overlay, and readiness status surfaces.
+
+## Task 1: Add Readiness Persistence And Status Models
+
+**Files:**
+- Modify: `app/config.py`
+- Modify: `app/database.py`
+- Modify: `app/schemas.py`
+- Test: `tests/test_preform_setup.py`
+
+- [ ] **Step 1: Write the failing readiness-status test**
+
+```python
+def test_setup_status_defaults_to_not_installed(tmp_path):
+    settings = _build_settings(tmp_path)
+    init_db(settings)
+
+    status = get_preform_setup_status(settings)
+
+    assert status.readiness == "not_installed"
+    assert status.install_path == str(settings.preform_managed_dir)
+    assert status.managed_executable_path == str(settings.preform_managed_executable)
+    assert status.detected_version is None
+    assert status.last_error_code is None
+```
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_preform_setup.py::test_setup_status_defaults_to_not_installed -q`
+Expected: FAIL because the setup status model and persistence surface do not exist yet.
+
+- [ ] **Step 2: Add config fields for the managed install contract**
+
+```python
+appdata_root = Path(os.getenv("ANDENT_WEB_APPDATA_DIR", os.getenv("APPDATA", resolved_data_dir / "appdata")))
+managed_root = appdata_root / "Andent Web"
+managed_dir = managed_root / "PreFormServer"
+
+return Settings(
+    ...,
+    appdata_dir=managed_root,
+    preform_server_port=int(os.getenv("ANDENT_WEB_PREFORM_PORT", "44388")),
+    preform_managed_dir=managed_dir,
+    preform_managed_executable=managed_dir / "PreFormServer.exe",
+    preform_server_startup_timeout_s=int(os.getenv("ANDENT_WEB_PREFORM_STARTUP_TIMEOUT_S", "30")),
+    preform_server_shutdown_timeout_s=int(os.getenv("ANDENT_WEB_PREFORM_SHUTDOWN_TIMEOUT_S", "10")),
+    preform_min_zip_size_bytes=int(os.getenv("ANDENT_WEB_PREFORM_MIN_ZIP_SIZE_BYTES", str(10 * 1024 * 1024))),
+    preform_min_supported_version=os.getenv("ANDENT_WEB_PREFORM_MIN_VERSION", "3.55.0"),
+    preform_max_supported_version=os.getenv("ANDENT_WEB_PREFORM_MAX_VERSION") or None,
+)
+```
+
+- [ ] **Step 3: Add one persisted setup-state table plus row mapping**
+
+```python
+CREATE TABLE IF NOT EXISTS preform_setup_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    readiness TEXT NOT NULL,
+    install_path TEXT NOT NULL,
+    managed_executable_path TEXT NOT NULL,
+    detected_version TEXT,
+    last_health_check_at TEXT,
+    last_error_code TEXT,
+    last_error_message TEXT,
+    active_configured_source INTEGER NOT NULL DEFAULT 1,
+    process_id INTEGER,
+    updated_at TEXT NOT NULL
+)
+```
+
+```python
+def save_preform_setup_state(settings: Settings, **changes: object) -> None:
+    now = _now_iso()
+    current = get_preform_setup_state(settings)
+    payload = {
+        "readiness": changes.get("readiness", current["readiness"]),
+        "install_path": changes.get("install_path", current["install_path"]),
+        "managed_executable_path": changes.get("managed_executable_path", current["managed_executable_path"]),
+        "detected_version": changes.get("detected_version", current["detected_version"]),
+        "last_health_check_at": changes.get("last_health_check_at", current["last_health_check_at"]),
+        "last_error_code": changes.get("last_error_code", current["last_error_code"]),
+        "last_error_message": changes.get("last_error_message", current["last_error_message"]),
+        "active_configured_source": 1 if changes.get("active_configured_source", current["active_configured_source"]) else 0,
+        "process_id": changes.get("process_id", current["process_id"]),
+        "updated_at": now,
+    }
+```
+
+- [ ] **Step 4: Add the setup schemas**
+
+```python
+PreFormReadiness = Literal["not_installed", "installed_not_running", "incompatible_version", "ready", "failed"]
+
+
+class PreFormSetupStatus(BaseModel):
+    readiness: PreFormReadiness
+    install_path: str
+    managed_executable_path: str
+    detected_version: str | None = None
+    expected_version_min: str
+    expected_version_max: str | None = None
+    active_configured_source: bool = True
+    is_running: bool = False
+    last_health_check_at: str | None = None
+    last_error_code: str | None = None
+    last_error_message: str | None = None
+
+
+class PreFormSetupActionResponse(BaseModel):
+    status: PreFormSetupStatus
+    message: str
+```
+
+- [ ] **Step 5: Run the readiness-status test**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_preform_setup.py::test_setup_status_defaults_to_not_installed -q`
+Expected: PASS.
+
+## Task 2: Add The Managed Install And Readiness Service
+
+**Files:**
+- Create: `app/services/preform_setup_service.py`
+- Test: `tests/test_preform_setup.py`
+
+- [ ] **Step 1: Write the failing ZIP-install and compatibility tests**
+
+```python
+def test_install_from_zip_extracts_managed_copy_and_marks_ready(tmp_path):
+    settings = _build_settings(tmp_path)
+    init_db(settings)
+    archive_path = _build_preform_zip(tmp_path, version_text="3.57.2.624")
+
+    manager = PreFormSetupService(settings)
+    manager._launch_process = lambda executable: 4242
+    manager._probe_server = lambda: {"healthy": True, "version": "3.57.2.624"}
+
+    status = manager.install_from_zip(archive_path)
+
+    assert status.readiness == "ready"
+    assert settings.preform_managed_executable.exists()
+    assert status.detected_version == "3.57.2.624"
+
+
+def test_install_from_zip_rejects_archive_without_preformserver_exe(tmp_path):
+    settings = _build_settings(tmp_path)
+    init_db(settings)
+    archive_path = _build_invalid_zip(tmp_path)
+
+    manager = PreFormSetupService(settings)
+
+    with pytest.raises(PreFormSetupError) as exc_info:
+        manager.install_from_zip(archive_path)
+
+    assert exc_info.value.code == "bad_zip"
+```
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_preform_setup.py -q`
+Expected: FAIL because the service does not exist yet.
+
+- [ ] **Step 2: Implement ZIP validation, staging, replace, and version checks**
+
+```python
+class PreFormSetupError(RuntimeError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+class PreFormSetupService:
+    def install_from_zip(self, archive_path: Path) -> PreFormSetupStatus:
+        self._validate_zip(archive_path)
+        staged_dir = self._extract_to_staging(archive_path)
+        payload_dir = self._resolve_payload_root(staged_dir)
+        self.stop(ignore_missing=True)
+        self._replace_managed_install(payload_dir)
+        self.start()
+        return self.recheck()
+```
+
+```python
+def _validate_zip(self, archive_path: Path) -> None:
+    if not archive_path.exists():
+        raise PreFormSetupError("bad_zip", "Selected ZIP file does not exist.")
+    if archive_path.suffix.lower() != ".zip":
+        raise PreFormSetupError("bad_zip", "Select a .zip package for PreFormServer.")
+    if archive_path.stat().st_size < self.settings.preform_min_zip_size_bytes:
+        raise PreFormSetupError("bad_zip", "Selected ZIP is smaller than the minimum supported package size.")
+    with zipfile.ZipFile(archive_path) as archive:
+        members = [Path(name) for name in archive.namelist() if not name.endswith("/")]
+    if "PreFormServer.exe" not in {member.name for member in members}:
+        raise PreFormSetupError("bad_zip", "ZIP does not contain a supported PreFormServer.exe layout.")
+```
+
+- [ ] **Step 3: Implement start, stop, restart, recheck, and readiness derivation**
+
+```python
+def recheck(self) -> PreFormSetupStatus:
+    if not self.settings.preform_managed_executable.exists():
+        return self._persist_status(readiness="not_installed", error_code=None, error_message=None, detected_version=None, is_running=False)
+
+    probe = self._probe_server()
+    if not probe["healthy"]:
+        return self._persist_status(readiness="installed_not_running", error_code=probe["code"], error_message=probe["message"], detected_version=None, is_running=False)
+
+    version = probe["version"]
+    if not self._version_is_supported(version):
+        return self._persist_status(readiness="incompatible_version", error_code="incompatible_version", error_message=f"Detected PreFormServer {version} is outside the supported range.", detected_version=version, is_running=True)
+
+    return self._persist_status(readiness="ready", error_code=None, error_message=None, detected_version=version, is_running=True)
+```
+
+- [ ] **Step 4: Run the setup-service tests**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_preform_setup.py -q`
+Expected: PASS.
+
+## Task 3: Expose Setup Routes And Block Print Until Ready
+
+**Files:**
+- Create: `app/routers/preform_setup.py`
+- Modify: `app/main.py`
+- Modify: `app/services/print_queue_service.py`
+- Modify: `app/routers/uploads.py`
+- Test: `tests/test_preform_setup.py`
+
+- [ ] **Step 1: Write the failing API tests for status, install, and blocked print**
+
+```python
+def test_status_route_returns_not_installed_for_fresh_app(tmp_path):
+    client, settings = _build_client(tmp_path)
+
+    response = client.get("/api/preform-setup/status")
+
+    assert response.status_code == 200
+    assert response.json()["readiness"] == "not_installed"
+
+
+def test_send_to_print_returns_409_when_preform_not_ready(tmp_path):
+    client, settings = _build_client_with_ready_row(tmp_path)
+
+    response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": [1]})
+
+    assert response.status_code == 409
+    assert "PreFormServer setup is required" in response.json()["detail"]
+```
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_preform_setup.py::test_status_route_returns_not_installed_for_fresh_app tests/test_preform_setup.py::test_send_to_print_returns_409_when_preform_not_ready -q`
+Expected: FAIL because the route surface and readiness gate do not exist yet.
+
+- [ ] **Step 2: Add the setup router**
+
+```python
+router = APIRouter(prefix="/api/preform-setup", tags=["preform-setup"])
+
+
+@router.get("/status", response_model=PreFormSetupStatus)
+async def get_status(request: Request) -> PreFormSetupStatus:
+    return PreFormSetupService(request.app.state.settings).recheck()
+
+
+@router.post("/install-from-zip", response_model=PreFormSetupActionResponse)
+async def install_from_zip(request: Request, package: UploadFile = File(...)) -> PreFormSetupActionResponse:
+    status = await _save_upload_then_call(request.app.state.settings, package, "install")
+    return PreFormSetupActionResponse(status=status, message="PreFormServer installed and verified.")
+```
+
+- [ ] **Step 3: Enforce the hard gate before handoff**
+
+```python
+def assert_preform_ready(settings: "Settings") -> None:
+    status = PreFormSetupService(settings).recheck()
+    if status.readiness != "ready":
+        raise ValueError(f"PreFormServer setup is required before printing ({status.readiness}).")
+
+
+def send_ready_rows_to_print(settings: "Settings", row_ids: list[int]) -> list["ClassificationRow"]:
+    assert_preform_ready(settings)
+    ...
+```
+
+- [ ] **Step 4: Run the route and gate tests**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_preform_setup.py -q`
+Expected: PASS.
+
+## Task 4: Add The Setup Center, First-Run Wizard, And UI Gating
+
+**Files:**
+- Modify: `app/static/index.html`
+- Modify: `app/static/app.js`
+- Modify: `app/static/styles.css`
+
+- [ ] **Step 1: Add the setup-center HTML shell**
+
+```html
+<section id="preform-banner" class="setup-banner hidden"></section>
+
+<section id="preform-setup-panel" class="panel setup-panel">
+  <div class="setup-panel-header">
+    <div>
+      <p class="eyebrow">PreFormServer</p>
+      <h2>Setup Center</h2>
+    </div>
+    <span id="preform-readiness-pill" class="status-pill">Checking</span>
+  </div>
+  <p id="preform-summary" class="setup-summary"></p>
+  <div class="setup-meta-grid">
+    <div><span>Install Path</span><strong id="preform-install-path"></strong></div>
+    <div><span>Detected Version</span><strong id="preform-version"></strong></div>
+  </div>
+  <div class="setup-actions">
+    <input id="preform-zip-input" type="file" accept=".zip" hidden>
+    <button id="preform-install-button" class="primary-button" type="button">Install or Replace ZIP</button>
+    <button id="preform-start-button" class="secondary-button" type="button">Start</button>
+    <button id="preform-restart-button" class="secondary-button" type="button">Restart</button>
+    <button id="preform-recheck-button" class="ghost-button" type="button">Re-check</button>
+  </div>
+</section>
+
+<div id="preform-wizard" class="wizard-shell hidden" aria-hidden="true"></div>
+```
+
+- [ ] **Step 2: Load and render setup status in the frontend**
+
+```javascript
+state.preformSetup = { status: null, loading: false };
+
+async function fetchPreformSetupStatus() {
+    const response = await fetch("/api/preform-setup/status");
+    const payload = await response.json();
+    if (!response.ok) {
+        throw new Error(payload.detail || "Could not load PreFormServer status.");
+    }
+    state.preformSetup.status = payload;
+}
+
+function canPrint() {
+    return state.preformSetup.status?.readiness === "ready";
+}
+```
+
+- [ ] **Step 3: Disable or intercept `Send to Print` when readiness is not ready**
+
+```javascript
+if (readyRows.length > 0) {
+    const submitButton = document.createElement("button");
+    submitButton.type = "button";
+    submitButton.className = "primary-button";
+    submitButton.textContent = canPrint()
+        ? `Send to Print (${readyRows.length})`
+        : `Setup Required (${readyRows.length})`;
+    submitButton.disabled = !canPrint();
+    submitButton.addEventListener("click", async () => {
+        if (!canPrint()) {
+            openPreformWizard();
+            return;
+        }
+        ...
+    });
+}
+```
+
+- [ ] **Step 4: Add the wizard/degraded-state styling**
+
+```css
+.setup-banner { border: 1px solid var(--warn); background: var(--warn-soft); }
+.setup-panel { display: grid; gap: 16px; }
+.wizard-shell {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+    display: grid;
+    place-items: center;
+    background: rgba(17, 17, 16, 0.68);
+}
+.wizard-card {
+    width: min(760px, calc(100vw - 32px));
+    padding: 32px;
+    border-radius: 18px;
+    background: var(--surface);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.24);
+}
+```
+
+- [ ] **Step 5: Manual browser verification**
+
+Run: `python -m uvicorn app.main:app --reload --port 8090`
+Expected:
+- Fresh app shows the setup center as `not_installed`.
+- The wizard appears on first load until dismissed or setup completes.
+- `Send to Print` is blocked until readiness becomes `ready`.
+
+## Task 5: Verification Sweep
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run the focused setup tests**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_preform_setup.py tests/test_preform_handoff.py tests/test_print_queue.py -q`
+Expected: PASS.
+
+- [ ] **Step 2: Run the broader repository suite**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 3: Review the final diff**
+
+Run: `git diff --stat`
+Expected: diff includes setup service, setup router, config/schema/database changes, print gate changes, and queue UI updates.
+
+## Self-Review
+
+### Spec Coverage
+
+This plan covers:
+
+1. Canonical managed install path: Tasks 1 and 2
+2. ZIP validation, staging, and replacement: Task 2
+3. Version compatibility enforcement: Task 2
+4. Persistent readiness state: Task 1
+5. Dedicated setup API surface: Task 3
+6. Hard print gate before handoff: Task 3
+7. First-run wizard and persistent maintenance panel: Task 4
+8. Degraded-state UI and queue messaging: Task 4
+9. Focused and broader verification: Task 5
+
+No design requirement is left without an implementation task.
+
+### Placeholder Scan
+
+Checked for `TBD`, `TODO`, unresolved “handle later” steps, and dangling type names. None remain.
+
+### Type Consistency
+
+The plan consistently uses:
+
+1. `PreFormSetupService`
+2. `PreFormSetupStatus`
+3. `PreFormSetupActionResponse`
+4. `assert_preform_ready()`
+5. `preform_setup_state`
+
+Those names stay aligned across config, persistence, API, service, and UI tasks.

--- a/docs/superpowers/specs/2026-04-21-playwright-release-gate-design.md
+++ b/docs/superpowers/specs/2026-04-21-playwright-release-gate-design.md
@@ -1,12 +1,14 @@
 # Playwright Release Gate Design
 
 Date: 2026-04-21
-Status: Updated for implemented Form 4BL build-manifest handoff
+Status: Updated after design approval and implementation-plan alignment
 Scope: Release-blocking end-to-end acceptance gate for Andent Web
 
 ## Summary
 
 This design defines a Playwright-driven release gate for Andent Web that simulates operator behavior in the browser while using a live PreFormServer instance on `http://localhost:44388` for handoff verification.
+
+Execution model, approved on 2026-04-21: the gate is release-blocking in policy, but it runs as a local pre-release command rather than as a normal CI job. This reflects the hard dependency on a live local PreFormServer instance for real handoff proof.
 
 Implementation context, 2026-04-21: Andent Web now plans compatibility-aware Form 4BL build manifests before PreFormServer handoff. The release gate therefore verifies the browser journey plus the build-manifest handoff evidence persisted by the app. The gate still remains narrow and does not expand into broad batching coverage.
 
@@ -54,6 +56,20 @@ The release gate consists of exactly four scenarios:
 4. Offline failure path.
 
 Anything beyond those four scenarios is out of scope for the first gate and should remain in normal pytest or later acceptance expansion.
+
+## Execution Model
+
+The first release gate should run as a local human-executed pre-release command.
+
+This is still a release blocker. The difference is execution surface, not importance. A release should not be cut unless this gate passes against the real local PreFormServer boundary.
+
+This design intentionally does not make the full gate a standard CI requirement because:
+
+1. The happy paths require a live local PreFormServer instance on `http://localhost:44388`.
+2. The gate is meant to prove the real browser-to-app-to-PreForm handoff boundary, not a mocked or substituted environment.
+3. Forcing that dependency into normal CI would make the first gate less trustworthy, not more trustworthy.
+
+If the repository later adds a separate CI browser smoke lane, that should be treated as an earlier feedback layer rather than as a replacement for this release gate.
 
 ## Scenario Contract
 
@@ -136,6 +152,8 @@ Responsibilities:
 
 This keeps startup and health logic out of UI steps.
 
+The runner should be implemented as a local release-gate command that invokes Playwright, reads the resulting scenario report, and prints a compact release summary for the operator.
+
 ### Layer 2: Playwright Acceptance Tests
 
 The Playwright layer owns operator simulation only.
@@ -186,6 +204,8 @@ The first implementation should keep the fixture set minimal:
 
 The offline failure path can reuse a sendable fixture from the happy-path or manual-edit set.
 
+The fixtures should be tiny committed ASCII STL files. Their job is deterministic filename-driven classification and stable release-gate behavior, not realistic geometry complexity.
+
 The first gate should not add a fifth mixed-preset scenario only to prove build planning. If compatible mixed-preset proof is needed for release confidence, fold it into either the straight-through path or the manual-edit path while keeping the approved four-scenario shape.
 
 ## Runtime Model
@@ -199,6 +219,8 @@ Responsibilities of the gate:
 4. Shut down both app instances after the run.
 
 The gate does not own starting or stopping the live PreFormServer process itself. It assumes the service is already available locally and checks health before beginning.
+
+The gate should fail fast when live PreFormServer health is unavailable instead of continuing into browser scenarios that would produce ambiguous downstream failures.
 
 This is the safest split between automation and environmental stability:
 1. It keeps the app runtime deterministic.
@@ -256,6 +278,16 @@ On failure:
 3. Record enough context to distinguish UI failure, app failure, and external verification failure.
 
 This output should be suitable for a release decision without requiring someone to reconstruct the failure from raw logs alone.
+
+The happy-path summaries should also include a compact manifest proof line with:
+
+1. `scene_id`
+2. `print_job_id`
+3. `case_ids`
+4. `preset_names`
+5. `compatibility_key`
+6. import group count
+7. file count
 
 ## Recommended File Layout
 

--- a/docs/superpowers/specs/2026-04-21-preformserver-setup-wizard-design.md
+++ b/docs/superpowers/specs/2026-04-21-preformserver-setup-wizard-design.md
@@ -1,0 +1,389 @@
+# PreFormServer Setup Wizard Design
+
+Date: 2026-04-21
+Status: Approved design
+Scope: First-run setup, managed install, version gating, and maintenance flow for local PreFormServer on Windows
+
+## Summary
+
+This design adds a managed `PreFormServer Setup Wizard` to Andent Web.
+
+The wizard is a real product feature, not only a test prerequisite. It guides the user through local ZIP-based installation, managed replacement with newer ZIPs, service start and restart, health verification, and version compatibility checks for the local PreFormServer dependency.
+
+The wizard is also a hard print gate. Print-dependent features must remain blocked until the managed PreFormServer install is present, compatible, and healthy.
+
+The first version supports local ZIP install and local ZIP replacement only. It does not download installers from the network.
+
+## Problem
+
+Andent Web now depends on a live local PreFormServer instance for real print handoff, but the current product experience assumes that dependency is already installed, already running, and already compatible.
+
+That leads to the wrong user experience:
+
+1. First-run users hit raw connection failures instead of a guided setup flow.
+2. Version mismatch and upgrade handling are implicit rather than explicit.
+3. Release-gate verification depends on machine state that the app does not help manage.
+4. Supportability suffers when the app has no single managed install path or maintenance surface.
+
+The system needs one clear answer to the question, "Is this machine ready for print handoff?"
+
+## Goals
+
+1. Provide a first-run wizard that guides users to install and start PreFormServer from a local ZIP.
+2. Keep one canonical managed PreFormServer install owned by Andent Web.
+3. Block print-dependent features until PreFormServer readiness is confirmed.
+4. Detect and explain distinct readiness failures such as missing install, stopped service, incompatible version, invalid ZIP, or failed health check.
+5. Reuse the same surface later for repair, restart, and ZIP-based update.
+6. Preserve a clean path for future release-gate automation: `wizard -> ready -> print handoff`.
+
+## Non-Goals
+
+1. Download PreFormServer from a remote source in v1.
+2. Search the whole machine for arbitrary unmanaged PreFormServer copies and adopt them automatically.
+3. Replace PreFormServer's own print logic, queueing, or layout behavior.
+4. Add cross-platform installer support in the first version; this design is scoped to Windows.
+5. Hide every low-level detail from the user. The wizard should be guided, but still explicit about failures.
+
+## Core Principle
+
+Andent Web should manage and verify one canonical local PreFormServer install.
+
+That means:
+
+1. One expected install location.
+2. One expected launch command.
+3. One explicit version-compatibility contract.
+4. One readiness state machine shared by first-run setup, ongoing maintenance, and print gating.
+
+The product should not rely on "whatever PreFormServer happens to be installed somewhere on this machine" in the first version.
+
+## Readiness Lifecycle
+
+The app should expose a `PreFormServer readiness` state with four main states:
+
+1. `not_installed`
+   No managed install exists in the expected location.
+2. `installed_not_running`
+   A managed install exists, but the local API is not reachable.
+3. `incompatible_version`
+   A managed install exists, but the detected version is outside the accepted contract.
+4. `ready`
+   The managed install exists, the version is accepted, and the local API passes health checks.
+
+Additional transient sub-states may exist internally for UX and orchestration:
+
+1. `installing`
+2. `replacing`
+3. `starting`
+4. `checking_health`
+5. `failed`
+
+These transient states support progress UI, but the persistent user-facing readiness contract should stay simple.
+
+## Product Gating
+
+PreFormServer readiness should be a hard gate for print-dependent actions.
+
+If readiness is not `ready`:
+
+1. `Send to Print` must be disabled or intercepted.
+2. Any print handoff attempt must redirect the user into the setup flow instead of surfacing a raw connection error.
+3. Print Queue surfaces may remain visible, but must clearly show setup state instead of pretending live queue operations are available.
+
+If readiness is `ready`:
+
+1. Print actions are enabled.
+2. Queue polling and handoff use the managed PreFormServer configuration.
+
+This preserves intake and review workflows while preventing avoidable handoff failures.
+
+## User Experience Model
+
+The first-run wizard should be the first face of a persistent `PreFormServer Setup Center`.
+
+That means the same underlying system supports:
+
+1. first-run install
+2. update required flow
+3. restart and repair
+4. re-check health
+5. replace with newer ZIP
+
+### First Run
+
+On first run, if readiness is anything other than `ready`, the user should land in a full-screen setup wizard before using print-dependent functionality.
+
+The wizard should explain:
+
+1. why PreFormServer is required
+2. what Andent Web will manage locally
+3. what ZIP the user needs to select
+4. what success looks like
+
+### Ongoing Maintenance
+
+After setup, the same capabilities should remain available from a persistent maintenance surface such as Settings or an equivalent operations panel.
+
+The app should also show a degraded-state banner or card when readiness falls out of `ready`.
+
+## Install Location
+
+The first version should use one app-managed Windows install location:
+
+`%APPDATA%/Andent Web/PreFormServer/`
+
+This location is recommended because it:
+
+1. matches the local-user, local-app ownership model
+2. avoids ambiguity about which copy Andent Web is launching
+3. makes replace and repair flows predictable
+4. aligns with the historical Formflow Dent direction captured in the repository notes
+
+## ZIP-Based Install Flow
+
+The first version supports local ZIP selection only.
+
+Example source:
+
+`D:\Marcus\Downloads\PreFormServer_3.57.2.624.zip`
+
+### Install Steps
+
+1. Detect current readiness state.
+2. Ask the user to choose a local ZIP file.
+3. Validate the ZIP before extraction.
+4. Extract to a staging directory, not directly into the managed install path.
+5. Verify the staged contents contain the expected executable layout.
+6. Replace the managed install atomically from staging.
+7. Launch the managed `PreFormServer.exe` on the configured port.
+8. Poll health until success or timeout.
+9. Read and validate the reported version.
+10. Mark readiness as `ready` and unlock print features.
+
+### ZIP Validation Rules
+
+Before install or replace, the app should verify:
+
+1. the selected file exists
+2. the extension is `.zip`
+3. file size exceeds a minimum sanity threshold
+4. the archive contains the expected `PreFormServer.exe` payload layout
+
+If validation fails, the wizard must explain whether the failure is:
+
+1. wrong file type
+2. corrupt archive
+3. missing executable layout
+4. unsupported package shape
+
+## Update Flow
+
+Updates should reuse the same ZIP-driven mechanism as install.
+
+If the installed version is incompatible:
+
+1. readiness becomes `incompatible_version`
+2. print-dependent actions remain blocked
+3. the setup center shows `Update Required`
+4. the user selects a newer local ZIP
+5. the app stages, replaces, restarts, and re-verifies
+
+The first version should support replacement with a newer ZIP, but not direct online download.
+
+## Service Control
+
+The backend should own managed process control for the canonical install.
+
+Supported actions:
+
+1. `start`
+2. `stop`
+3. `restart`
+4. `recheck`
+
+The launch path should be explicit and stable:
+
+`%APPDATA%/Andent Web/PreFormServer/PreFormServer.exe --port 44388`
+
+If port binding fails or startup times out, the readiness state should move to a failure state with a clear explanation.
+
+## Version Compatibility
+
+The app should enforce a version-compatibility contract instead of relying on best effort.
+
+The first version should use a pinned supported version or a tightly bounded accepted range defined in one place. The wizard then compares the detected PreFormServer version against that contract during:
+
+1. startup
+2. install completion
+3. manual re-check
+
+If the version is incompatible:
+
+1. readiness becomes `incompatible_version`
+2. handoff remains blocked
+3. the setup center prompts for replacement with a newer ZIP
+
+## Architecture
+
+The design should stay narrow and service-oriented.
+
+### 1. `preformserver_manager`
+
+A backend service should own:
+
+1. managed install-path resolution
+2. ZIP validation
+3. staged extraction
+4. atomic replace
+5. process launch and stop
+6. health polling
+7. version detection
+8. readiness-state evaluation
+
+### 2. Setup State Persistence
+
+A small persistence surface should track:
+
+1. managed install path
+2. detected version
+3. last successful health check
+4. last known readiness state
+5. last setup or startup error
+6. whether the managed install is the active configured source
+
+The persistence model should be simple enough to survive app restarts and support user-visible status.
+
+### 3. API Surface
+
+The backend should expose dedicated setup routes for:
+
+1. `GET status`
+2. `POST install-from-zip`
+3. `POST start`
+4. `POST stop`
+5. `POST restart`
+6. `POST recheck`
+7. `POST replace-from-zip`
+
+### 4. Frontend Surface
+
+The frontend should contain:
+
+1. a full-screen first-run wizard
+2. a persistent maintenance panel
+3. degraded-state banners or cards when readiness is not `ready`
+
+## Error Model
+
+The wizard must distinguish between different failure shapes. At minimum:
+
+1. `missing_install`
+2. `bad_zip`
+3. `install_failed`
+4. `start_failed`
+5. `port_unavailable`
+6. `health_check_failed`
+7. `incompatible_version`
+
+The UI should never collapse those into a single generic "PreFormServer error" message when the system already knows the precise problem.
+
+## Relationship To Release Gate
+
+This wizard is not the same feature as the Playwright release gate, but they should reinforce each other.
+
+The setup wizard improves the product dependency story for real users. The release gate then proves the browser-to-app-to-PreForm handoff on a prepared local machine.
+
+Longer term, the browser test story can cover:
+
+1. wizard gating before readiness
+2. setup success from a local ZIP
+3. transition into `ready`
+4. print handoff after readiness
+
+## Testing Strategy
+
+Testing should be split into three layers.
+
+### Unit Tests
+
+Required proof points:
+
+1. install-path resolution
+2. ZIP validation
+3. staged extraction and replace logic
+4. version parsing
+5. compatibility checks
+6. readiness-state derivation
+
+### Backend Integration Tests
+
+Required proof points:
+
+1. install-from-zip route behavior
+2. persisted readiness state
+3. startup and restart flows
+4. blocked print behavior when readiness is not `ready`
+5. successful transition from `not_installed` or `incompatible_version` to `ready`
+
+### Browser Tests
+
+Required proof points:
+
+1. first-run wizard appears when readiness is not `ready`
+2. print actions are blocked before setup
+3. local ZIP install flow completes successfully
+4. incompatible version state prompts for replacement
+5. print actions unlock only after readiness becomes `ready`
+
+## Risks And Mitigations
+
+### Risk: Installer ambiguity
+
+If the app supports arbitrary unmanaged PreFormServer copies in v1, compatibility and supportability become unclear.
+
+Mitigation:
+
+1. Use one canonical managed install path.
+2. Make the wizard own that copy explicitly.
+
+### Risk: Half-installed state
+
+If extraction writes directly into the live install path, interrupted installs may leave the product unusable.
+
+Mitigation:
+
+1. Always extract to staging.
+2. Replace atomically after validation.
+
+### Risk: Confusing print failures
+
+If readiness is known but the UI still exposes live print actions, users will keep hitting raw connection errors.
+
+Mitigation:
+
+1. Enforce a hard print gate.
+2. Redirect setup-related failures into the wizard rather than surfacing transport errors first.
+
+### Risk: Scope creep into generic updater infrastructure
+
+If v1 tries to support remote downloads, generic package management, or unmanaged install adoption, delivery risk rises quickly.
+
+Mitigation:
+
+1. Keep v1 local-ZIP only.
+2. Keep version management explicit and narrow.
+
+## Acceptance For This Design
+
+This design is complete when implementation planning can answer:
+
+1. where readiness state is persisted
+2. how ZIP validation identifies a supported PreFormServer package
+3. how staging and atomic replace are implemented on Windows
+4. how process lifecycle is managed safely by the backend
+5. how the frontend routes first-run users into the wizard
+6. how print actions are gated when readiness is not `ready`
+7. which version contract the app enforces in the first release
+8. which unit, integration, and browser tests lock the setup and gating behavior
+
+Those are implementation-plan questions, not unresolved design questions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "andent-web-release-gate",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "andent-web-release-gate",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "@types/node": "^22.15.3",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "andent-web-release-gate",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:release-gate": "node scripts/release_gate/run_release_gate.mjs",
+    "test:release-gate:headed": "playwright test tests/release_gate/smoke.spec.ts --project=chromium --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^22.15.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/release_gate',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [
+    ['line'],
+    ['json', { outputFile: 'test-results/release-gate/results.json' }],
+  ],
+  outputDir: 'test-results/playwright',
+  use: {
+    baseURL: 'http://127.0.0.1:8090',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: `python -c "import os, shutil; from pathlib import Path; data_dir = Path('test-results/playwright-app'); shutil.rmtree(data_dir, ignore_errors=True); os.environ['ANDENT_WEB_DATA_DIR'] = str(data_dir); os.environ['ANDENT_WEB_DATABASE_PATH'] = str(data_dir / 'andent_web.db'); os.environ['ANDENT_WEB_APPDATA_DIR'] = str(data_dir / 'appdata'); import uvicorn; uvicorn.run('app.main:app', host='127.0.0.1', port=8090)"`,
+    url: 'http://127.0.0.1:8090/health',
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+});

--- a/scripts/release_gate/run_release_gate.mjs
+++ b/scripts/release_gate/run_release_gate.mjs
@@ -1,0 +1,41 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+
+const resultsFile = 'test-results/release-gate/results.json';
+
+const exitCode = await new Promise((resolve) => {
+  const command = 'npx playwright test tests/release_gate/release_gate.spec.ts --project=chromium';
+  const child = spawn(
+    command,
+    [],
+    { stdio: 'inherit', shell: true },
+  );
+  child.on('exit', (code) => resolve(code ?? 1));
+});
+
+try {
+  const report = JSON.parse(await fs.readFile(resultsFile, 'utf8'));
+  const suites = report.suites ?? [];
+  const stack = [...suites];
+  const specs = [];
+  while (stack.length > 0) {
+    const suite = stack.shift();
+    if (!suite) {
+      continue;
+    }
+    specs.push(...(suite.specs ?? []));
+    stack.push(...(suite.suites ?? []));
+  }
+
+  for (const spec of specs) {
+    const tests = spec.tests ?? [];
+    for (const item of tests) {
+      const result = item.results?.[0];
+      console.log(`[release-gate] ${spec.title}: ${result?.status ?? 'unknown'}`);
+    }
+  }
+} catch (error) {
+  console.error(`[release-gate] could not read ${resultsFile}: ${error}`);
+}
+
+process.exit(exitCode);

--- a/tests/release_gate/fixtures/ambiguous/Julie_UpperJaw.stl
+++ b/tests/release_gate/fixtures/ambiguous/Julie_UpperJaw.stl
@@ -1,0 +1,16 @@
+solid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 5
+      vertex 0 20 5
+      vertex 20 0 5
+    endloop
+  endfacet
+endsolid release_gate_fixture

--- a/tests/release_gate/fixtures/ambiguous/Julie_UpperJaw.stl
+++ b/tests/release_gate/fixtures/ambiguous/Julie_UpperJaw.stl
@@ -1,16 +1,86 @@
-solid release_gate_fixture
-  facet normal 0 0 1
+solid ambiguous_cube
+  facet normal 0 0 -1
     outer loop
       vertex 0 0 0
-      vertex 20 0 0
-      vertex 0 20 0
+      vertex 16 16 0
+      vertex 16 0 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 0 5
-      vertex 0 20 5
-      vertex 20 0 5
+      vertex 0 0 0
+      vertex 0 16 0
+      vertex 16 16 0
     endloop
   endfacet
-endsolid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 6
+      vertex 16 0 6
+      vertex 16 16 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 6
+      vertex 16 16 6
+      vertex 0 16 6
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 16 0 0
+      vertex 16 0 6
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 16 0 6
+      vertex 0 0 6
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 16 0
+      vertex 16 16 6
+      vertex 16 16 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 16 0
+      vertex 0 16 6
+      vertex 16 16 6
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 6
+      vertex 0 16 6
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 16 6
+      vertex 0 16 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 16 0 0
+      vertex 16 16 0
+      vertex 16 16 6
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 16 0 0
+      vertex 16 16 6
+      vertex 16 0 6
+    endloop
+  endfacet
+endsolid ambiguous_cube

--- a/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_LowerJaw.stl
+++ b/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_LowerJaw.stl
@@ -1,0 +1,16 @@
+solid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 24 0 0
+      vertex 0 18 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 5
+      vertex 0 18 6
+      vertex 24 0 6
+    endloop
+  endfacet
+endsolid release_gate_fixture

--- a/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_LowerJaw.stl
+++ b/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_LowerJaw.stl
@@ -1,16 +1,86 @@
-solid release_gate_fixture
-  facet normal 0 0 1
+solid lower_jaw_cube
+  facet normal 0 0 -1
     outer loop
       vertex 0 0 0
-      vertex 24 0 0
-      vertex 0 18 0
+      vertex 18 18 0
+      vertex 18 0 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 0 5
-      vertex 0 18 6
-      vertex 24 0 6
+      vertex 0 0 0
+      vertex 0 18 0
+      vertex 18 18 0
     endloop
   endfacet
-endsolid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 18 0 10
+      vertex 18 18 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 18 18 10
+      vertex 0 18 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 18 0 0
+      vertex 18 0 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 18 0 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 18 0
+      vertex 18 18 10
+      vertex 18 18 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 18 0
+      vertex 0 18 10
+      vertex 18 18 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 10
+      vertex 0 18 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 18 10
+      vertex 0 18 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 18 0 0
+      vertex 18 18 0
+      vertex 18 18 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 18 0 0
+      vertex 18 18 10
+      vertex 18 0 10
+    endloop
+  endfacet
+endsolid lower_jaw_cube

--- a/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_UpperJaw.stl
+++ b/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_UpperJaw.stl
@@ -1,0 +1,16 @@
+solid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 5
+      vertex 0 20 5
+      vertex 20 0 5
+    endloop
+  endfacet
+endsolid release_gate_fixture

--- a/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_UpperJaw.stl
+++ b/tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_UpperJaw.stl
@@ -1,16 +1,86 @@
-solid release_gate_fixture
-  facet normal 0 0 1
+solid upper_jaw_cube
+  facet normal 0 0 -1
     outer loop
       vertex 0 0 0
+      vertex 20 20 0
       vertex 20 0 0
-      vertex 0 20 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 0 5
-      vertex 0 20 5
-      vertex 20 0 5
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 20 20 0
     endloop
   endfacet
-endsolid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 8
+      vertex 20 0 8
+      vertex 20 20 8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 8
+      vertex 20 20 8
+      vertex 0 20 8
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 0 8
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 8
+      vertex 0 0 8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 8
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 8
+      vertex 20 20 8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 8
+      vertex 0 20 8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 8
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 0
+      vertex 20 20 8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 8
+      vertex 20 0 8
+    endloop
+  endfacet
+endsolid upper_jaw_cube

--- a/tests/release_gate/fixtures/manual_edit/20260409_CASE555_Tooth_46.stl
+++ b/tests/release_gate/fixtures/manual_edit/20260409_CASE555_Tooth_46.stl
@@ -1,0 +1,16 @@
+solid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 5
+      vertex 0 20 5
+      vertex 20 0 5
+    endloop
+  endfacet
+endsolid release_gate_fixture

--- a/tests/release_gate/fixtures/manual_edit/20260409_CASE555_Tooth_46.stl
+++ b/tests/release_gate/fixtures/manual_edit/20260409_CASE555_Tooth_46.stl
@@ -1,16 +1,86 @@
-solid release_gate_fixture
-  facet normal 0 0 1
+solid tooth_cube
+  facet normal 0 0 -1
     outer loop
       vertex 0 0 0
-      vertex 20 0 0
-      vertex 0 20 0
+      vertex 8 8 0
+      vertex 8 0 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 0 5
-      vertex 0 20 5
-      vertex 20 0 5
+      vertex 0 0 0
+      vertex 0 8 0
+      vertex 8 8 0
     endloop
   endfacet
-endsolid release_gate_fixture
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 14
+      vertex 8 0 14
+      vertex 8 8 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 14
+      vertex 8 8 14
+      vertex 0 8 14
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 8 0 0
+      vertex 8 0 14
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 8 0 14
+      vertex 0 0 14
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 8 0
+      vertex 8 8 14
+      vertex 8 8 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 8 0
+      vertex 0 8 14
+      vertex 8 8 14
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 14
+      vertex 0 8 14
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 8 14
+      vertex 0 8 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 8 0 0
+      vertex 8 8 0
+      vertex 8 8 14
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 8 0 0
+      vertex 8 8 14
+      vertex 8 0 14
+    endloop
+  endfacet
+endsolid tooth_cube

--- a/tests/release_gate/helpers/fixtures.ts
+++ b/tests/release_gate/helpers/fixtures.ts
@@ -1,0 +1,49 @@
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { test as base } from '@playwright/test';
+
+import { startAppInstance, stopAppInstance, type AppInstance } from './runtime.js';
+
+const execFileAsync = promisify(execFile);
+
+async function runVerify(args: string[]) {
+  const { stdout } = await execFileAsync('python', ['tests/release_gate/helpers/python/release_gate_verify.py', ...args]);
+  return JSON.parse(stdout);
+}
+
+export const test = base.extend<{
+  liveApp: AppInstance;
+  deadApp: AppInstance;
+  latestPrintJob: (databasePath: string) => Promise<any>;
+  sceneStatus: (baseUrl: string, sceneId: string) => Promise<any>;
+}>({
+  liveApp: [async ({}, use: (app: AppInstance) => Promise<void>) => {
+    const app = await startAppInstance({
+      dataDir: path.resolve('test-results/release-gate/live-app'),
+      preformUrl: 'http://127.0.0.1:44388',
+    });
+    await use(app);
+    await stopAppInstance(app);
+  }, { scope: 'test' }],
+
+  deadApp: [async ({}, use: (app: AppInstance) => Promise<void>) => {
+    const app = await startAppInstance({
+      dataDir: path.resolve('test-results/release-gate/dead-app'),
+      preformUrl: 'http://127.0.0.1:59999',
+    });
+    await use(app);
+    await stopAppInstance(app);
+  }, { scope: 'test' }],
+
+  latestPrintJob: async ({}, use: (fn: (databasePath: string) => Promise<any>) => Promise<void>) => {
+    await use((databasePath) => runVerify(['latest-print-job', '--database-path', databasePath]));
+  },
+
+  sceneStatus: async ({}, use: (fn: (baseUrl: string, sceneId: string) => Promise<any>) => Promise<void>) => {
+    await use((baseUrl, sceneId) => runVerify(['scene', '--base-url', baseUrl, '--scene-id', sceneId]));
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/release_gate/helpers/page.ts
+++ b/tests/release_gate/helpers/page.ts
@@ -1,0 +1,14 @@
+import { expect, type Page } from '@playwright/test';
+
+export async function waitForRowReady(page: Page, fileName: string): Promise<void> {
+  const row = page.locator(`[data-file-name="${fileName}"]`);
+  await expect(row).toBeVisible();
+  await expect(row.locator('[data-testid="status-chip"]')).toHaveText('Ready');
+}
+
+export async function dismissSetupWizardIfPresent(page: Page): Promise<void> {
+  const button = page.getByRole('button', { name: 'Continue Without Printing' });
+  if (await button.count()) {
+    await button.click();
+  }
+}

--- a/tests/release_gate/helpers/python/release_gate_verify.py
+++ b/tests/release_gate/helpers/python/release_gate_verify.py
@@ -58,7 +58,13 @@ def fetch_scene(base_url: str, scene_id: str) -> dict[str, Any]:
         timeout=30,
     )
     response.raise_for_status()
-    return response.json()
+    payload = response.json()
+    if isinstance(payload, dict) and "scene_id" not in payload and "id" in payload:
+        payload = {
+            **payload,
+            "scene_id": payload["id"],
+        }
+    return payload
 
 
 def fetch_health(base_url: str) -> dict[str, object]:

--- a/tests/release_gate/helpers/python/release_gate_verify.py
+++ b/tests/release_gate/helpers/python/release_gate_verify.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+def parse_health_response(payload: object) -> dict[str, object]:
+    version = _extract_version(payload)
+    return {
+        "healthy": True,
+        "version": version,
+    }
+
+
+def latest_print_job(database_path: Path | str) -> dict[str, Any]:
+    connection = sqlite3.connect(str(database_path))
+    connection.row_factory = sqlite3.Row
+    try:
+        row = connection.execute(
+            """
+            SELECT *
+            FROM print_jobs
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """
+        ).fetchone()
+    finally:
+        connection.close()
+
+    if row is None:
+        raise RuntimeError("No print jobs found.")
+
+    return {
+        "id": row["id"],
+        "job_name": row["job_name"],
+        "scene_id": row["scene_id"],
+        "print_job_id": row["print_job_id"],
+        "status": row["status"],
+        "preset": row["preset"],
+        "preset_names": _loads_list(row["preset_names_json"]),
+        "compatibility_key": row["compatibility_key"],
+        "case_ids": _loads_list(row["case_ids"]),
+        "manifest_json": _loads_dict(row["manifest_json"]),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def fetch_scene(base_url: str, scene_id: str) -> dict[str, Any]:
+    response = requests.get(
+        f"{base_url.rstrip('/')}/scene/{scene_id}",
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_health(base_url: str) -> dict[str, object]:
+    candidates = ["/", "/health", "/health/ready"]
+    last_error: Exception | None = None
+    for path in candidates:
+        try:
+            response = requests.get(f"{base_url.rstrip('/')}{path}", timeout=10)
+            response.raise_for_status()
+            return parse_health_response(_json_or_text(response))
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Health check did not produce a result.")
+
+
+def _json_or_text(response: requests.Response) -> object:
+    try:
+        return response.json()
+    except ValueError:
+        return response.text
+
+
+def _extract_version(payload: object) -> str | None:
+    if isinstance(payload, dict):
+        for key in ("version", "build_version", "preform_version", "server_version"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        for value in payload.values():
+            detected = _extract_version(value)
+            if detected:
+                return detected
+        return None
+    if isinstance(payload, list):
+        for item in payload:
+            detected = _extract_version(item)
+            if detected:
+                return detected
+        return None
+    if isinstance(payload, str):
+        match = re.search(r"\d+\.\d+\.\d+(?:\.\d+)?", payload)
+        return match.group(0) if match else None
+    return None
+
+
+def _loads_list(value: str | None) -> list[Any]:
+    if not value:
+        return []
+    loaded = json.loads(value)
+    return loaded if isinstance(loaded, list) else []
+
+
+def _loads_dict(value: str | None) -> dict[str, Any] | None:
+    if not value:
+        return None
+    loaded = json.loads(value)
+    return loaded if isinstance(loaded, dict) else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    latest_job_parser = subparsers.add_parser("latest-print-job")
+    latest_job_parser.add_argument("--database-path", required=True)
+
+    health_parser = subparsers.add_parser("health")
+    health_parser.add_argument("--base-url", required=True)
+
+    scene_parser = subparsers.add_parser("scene")
+    scene_parser.add_argument("--base-url", required=True)
+    scene_parser.add_argument("--scene-id", required=True)
+
+    args = parser.parse_args()
+
+    if args.command == "latest-print-job":
+        result = latest_print_job(Path(args.database_path))
+    elif args.command == "health":
+        result = fetch_health(args.base_url)
+    else:
+        result = fetch_scene(args.base_url, args.scene_id)
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release_gate/helpers/runtime.ts
+++ b/tests/release_gate/helpers/runtime.ts
@@ -1,0 +1,112 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs/promises';
+import net from 'node:net';
+import path from 'node:path';
+
+export type AppInstance = {
+  baseURL: string;
+  dataDir: string;
+  databasePath: string;
+  preformUrl: string;
+  process: ChildProcess;
+};
+
+type StartAppOptions = {
+  dataDir: string;
+  preformUrl: string;
+};
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Could not resolve an ephemeral port.'));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function waitForHealth(url: string): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Retry until timeout.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function seedManagedInstall(dataDir: string): Promise<void> {
+  const appDataDir = path.resolve(dataDir, 'appdata', 'Andent Web', 'PreFormServer');
+  await fs.mkdir(appDataDir, { recursive: true });
+  await fs.writeFile(path.join(appDataDir, 'PreFormServer.exe'), 'fake exe\n', 'utf8');
+  await fs.writeFile(path.join(appDataDir, 'version.txt'), '3.57.2.624\n', 'utf8');
+}
+
+export async function startAppInstance(options: StartAppOptions): Promise<AppInstance> {
+  const dataDir = path.resolve(options.dataDir);
+  const databasePath = path.join(dataDir, 'andent_web.db');
+  const port = await getFreePort();
+  await fs.rm(dataDir, { recursive: true, force: true });
+  await fs.mkdir(dataDir, { recursive: true });
+  await seedManagedInstall(dataDir);
+
+  const child = spawn(
+    'python',
+    ['-m', 'uvicorn', 'app.main:app', '--host', '127.0.0.1', '--port', String(port)],
+    {
+      cwd: path.resolve('.'),
+      env: {
+        ...process.env,
+        ANDENT_WEB_DATA_DIR: dataDir,
+        ANDENT_WEB_DATABASE_PATH: databasePath,
+        ANDENT_WEB_APPDATA_DIR: path.join(dataDir, 'appdata'),
+        PREFORM_SERVER_URL: options.preformUrl,
+      },
+      stdio: 'pipe',
+    },
+  );
+
+  const baseURL = `http://127.0.0.1:${port}`;
+  await waitForHealth(`${baseURL}/health`);
+
+  return {
+    baseURL,
+    dataDir,
+    databasePath,
+    preformUrl: options.preformUrl,
+    process: child,
+  };
+}
+
+export async function stopAppInstance(app: AppInstance): Promise<void> {
+  if (app.process.killed) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    app.process.once('exit', () => resolve());
+    app.process.kill();
+    setTimeout(() => resolve(), 5_000);
+  });
+}

--- a/tests/release_gate/release_gate.spec.ts
+++ b/tests/release_gate/release_gate.spec.ts
@@ -1,0 +1,128 @@
+import path from 'node:path';
+
+import { expect, test } from './helpers/fixtures.js';
+import { dismissSetupWizardIfPresent, waitForRowReady } from './helpers/page.js';
+
+function manifestSummary(job: any): Record<string, unknown> {
+  const importGroups = job.manifest_json?.import_groups ?? [];
+  const fileCount = importGroups.reduce(
+    (total: number, group: any) => total + (group.files?.length ?? 0),
+    0,
+  );
+  return {
+    job_name: job.job_name,
+    scene_id: job.scene_id,
+    print_job_id: job.print_job_id,
+    case_ids: job.case_ids,
+    preset_names: job.preset_names,
+    compatibility_key: job.compatibility_key,
+    import_group_count: importGroups.length,
+    file_count: fileCount,
+  };
+}
+
+test('straight-through same-case multi-file handoff reaches live PreForm', async ({ page, liveApp, latestPrintJob, sceneStatus }) => {
+  await page.goto(`${liveApp.baseURL}/`);
+  await expect(page.locator('#dropzone')).toBeVisible();
+  await page.locator('#file-input').setInputFiles([
+    path.resolve('tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_UpperJaw.stl'),
+    path.resolve('tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_LowerJaw.stl'),
+  ]);
+
+  await waitForRowReady(page, '20260409_CASE123_UnsectionedModel_UpperJaw.stl');
+  await waitForRowReady(page, '20260409_CASE123_UnsectionedModel_LowerJaw.stl');
+  await dismissSetupWizardIfPresent(page);
+
+  const upperRow = page.locator('[data-file-name="20260409_CASE123_UnsectionedModel_UpperJaw.stl"]');
+  await upperRow.locator('[data-testid="row-select"]').check();
+  await page.locator('[data-testid="send-to-print-button"]').click();
+  await expect(page.locator('#status-text')).toContainText('Moved 2 row(s) into Processed as Submitted.');
+
+  const job = await latestPrintJob(liveApp.databasePath);
+  expect(job.case_ids).toContain('CASE123');
+  expect(job.preset_names).toContain('Ortho Solid - Flat, No Supports');
+  expect(job.compatibility_key).toBeTruthy();
+  expect(job.manifest_json.case_ids).toContain('CASE123');
+  expect(job.manifest_json.planning_status).toBe('planned');
+  expect(job.manifest_json.import_groups.length).toBeGreaterThan(0);
+  const manifestFiles = job.manifest_json.import_groups.flatMap((group: any) => group.files);
+  expect(manifestFiles.map((file: any) => file.file_name)).toEqual(expect.arrayContaining([
+    '20260409_CASE123_UnsectionedModel_UpperJaw.stl',
+    '20260409_CASE123_UnsectionedModel_LowerJaw.stl',
+  ]));
+  expect(manifestFiles.every((file: any) => Boolean(file.preform_hint))).toBe(true);
+  console.log(`[release-gate-manifest] ${JSON.stringify(manifestSummary(job))}`);
+
+  const scene = await sceneStatus(liveApp.preformUrl, job.scene_id);
+  expect(scene.scene_id).toBe(job.scene_id);
+});
+
+test('manual model and preset edits still hand off to live PreForm', async ({ page, liveApp, latestPrintJob, sceneStatus }) => {
+  await page.goto(`${liveApp.baseURL}/`);
+  await expect(page.locator('#dropzone')).toBeVisible();
+  await page.locator('#file-input').setInputFiles([
+    path.resolve('tests/release_gate/fixtures/manual_edit/20260409_CASE555_Tooth_46.stl'),
+  ]);
+
+  await waitForRowReady(page, '20260409_CASE555_Tooth_46.stl');
+  await dismissSetupWizardIfPresent(page);
+  const row = page.locator('[data-file-name="20260409_CASE555_Tooth_46.stl"]');
+
+  await row.locator('[data-testid="model-type-select"]').selectOption('Ortho - Solid');
+  await row.locator('[data-testid="preset-select"]').selectOption('Splint - Flat, No Supports');
+  await expect(row.locator('[data-testid="status-chip"]')).toHaveText('Ready');
+
+  await row.locator('[data-testid="row-select"]').check();
+  await page.locator('[data-testid="send-to-print-button"]').click();
+  await expect(page.locator('#status-text')).toContainText('Moved 1 row(s) into Processed as Submitted.');
+
+  const job = await latestPrintJob(liveApp.databasePath);
+  expect(job.case_ids).toContain('CASE555');
+  expect(job.preset).toBe('Splint - Flat, No Supports');
+  expect(job.preset_names).toContain('Splint - Flat, No Supports');
+  expect(job.manifest_json.case_ids).toContain('CASE555');
+  const splintGroup = job.manifest_json.import_groups.find(
+    (group: any) => group.preset_name === 'Splint - Flat, No Supports',
+  );
+  expect(splintGroup).toBeTruthy();
+  expect(splintGroup?.preform_hint).toBe('splint_v1');
+  expect(splintGroup?.files[0].preform_hint).toBe('splint_v1');
+  console.log(`[release-gate-manifest] ${JSON.stringify(manifestSummary(job))}`);
+
+  const scene = await sceneStatus(liveApp.preformUrl, job.scene_id);
+  expect(scene.scene_id).toBe(job.scene_id);
+});
+
+test('ambiguous case stays blocked in Active and cannot be sent', async ({ page, liveApp }) => {
+  await page.goto(`${liveApp.baseURL}/`);
+  await expect(page.locator('#dropzone')).toBeVisible();
+  await dismissSetupWizardIfPresent(page);
+  await page.locator('#file-input').setInputFiles([
+    path.resolve('tests/release_gate/fixtures/ambiguous/Julie_UpperJaw.stl'),
+  ]);
+
+  const row = page.locator('[data-file-name="Julie_UpperJaw.stl"]');
+  await expect(row).toBeVisible();
+  await expect(row.locator('[data-testid="status-chip"]')).toHaveText('Needs Review');
+  await expect(page.locator('[data-testid="send-to-print-button"]')).toHaveCount(0);
+});
+
+test('dead-port PreForm configuration stays blocked behind setup gating', async ({ page, deadApp }) => {
+  await page.goto(`${deadApp.baseURL}/`);
+  await expect(page.locator('#dropzone')).toBeVisible();
+  await dismissSetupWizardIfPresent(page);
+  await page.locator('#file-input').setInputFiles([
+    path.resolve('tests/release_gate/fixtures/happy/20260409_CASE123_UnsectionedModel_UpperJaw.stl'),
+  ]);
+
+  await waitForRowReady(page, '20260409_CASE123_UnsectionedModel_UpperJaw.stl');
+  await dismissSetupWizardIfPresent(page);
+  const row = page.locator('[data-file-name="20260409_CASE123_UnsectionedModel_UpperJaw.stl"]');
+  await row.locator('[data-testid="row-select"]').check();
+
+  const button = page.locator('[data-testid="send-to-print-button"]');
+  await expect(button).toHaveText(/Setup Required/);
+  await button.click();
+  await expect(page.locator('#preform-wizard')).toBeVisible();
+  await expect(page.locator('#preform-summary')).toContainText('local API is not reachable');
+});

--- a/tests/release_gate/runtime.spec.ts
+++ b/tests/release_gate/runtime.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from './helpers/fixtures.js';
+
+test('runtime harness starts isolated app instances', async ({ request, liveApp, deadApp }) => {
+  const liveHealth = await request.get(`${liveApp.baseURL}/health`);
+  const deadHealth = await request.get(`${deadApp.baseURL}/health`);
+
+  expect(liveHealth.ok()).toBeTruthy();
+  expect(deadHealth.ok()).toBeTruthy();
+  expect(liveApp.baseURL).not.toBe(deadApp.baseURL);
+  expect(liveApp.dataDir).not.toBe(deadApp.dataDir);
+});

--- a/tests/release_gate/smoke.spec.ts
+++ b/tests/release_gate/smoke.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('home page boots in Chromium', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Active Queue' })).toBeVisible();
+  await expect(page.locator('#dropzone')).toBeVisible();
+  await expect(page.locator('#status-text')).toContainText('Queue loaded.');
+});

--- a/tests/release_gate/ui-hooks.spec.ts
+++ b/tests/release_gate/ui-hooks.spec.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+test('row hooks and preset sync are stable for browser automation', async ({ page }) => {
+  await page.goto('/');
+
+  await page.locator('#file-input').setInputFiles([
+    path.resolve('tests/release_gate/fixtures/manual_edit/20260409_CASE555_Tooth_46.stl'),
+  ]);
+
+  const row = page.locator('[data-file-name="20260409_CASE555_Tooth_46.stl"]');
+  await expect(row).toBeVisible();
+  await expect(row.locator('[data-testid="status-chip"]')).toHaveText('Ready');
+
+  await row.locator('[data-testid="model-type-select"]').selectOption('Ortho - Solid');
+  await expect(row.locator('[data-testid="preset-select"]')).toHaveValue('Ortho Solid - Flat, No Supports');
+});

--- a/tests/test_preform_client.py
+++ b/tests/test_preform_client.py
@@ -26,12 +26,12 @@ class TestPreFormClient:
         assert client.base_url == custom_url
 
     def test_create_scene_success(self):
-        """Test creating a scene successfully."""
+        """Test creating a scene with the current Local API scene-settings payload."""
         # Create a mock session
         mock_session = Mock()
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"scene_id": "scene-123", "status": "created"}
+        mock_response.json.return_value = {"id": "scene-123", "layer_count": 0}
         mock_session.post.return_value = mock_response
         
         client = PreFormClient()
@@ -39,10 +39,15 @@ class TestPreFormClient:
         
         result = client.create_scene(patient_id="P001", case_name="Test Case")
         
-        assert result == {"scene_id": "scene-123", "status": "created"}
+        assert result == {"id": "scene-123", "scene_id": "scene-123", "layer_count": 0}
         mock_session.post.assert_called_once_with(
             "http://localhost:44388/scene/",
-            json={"patient_id": "P001", "case_name": "Test Case"},
+            json={
+                "layer_thickness_mm": 0.1,
+                "machine_type": "FORM-4-0",
+                "material_code": "FLPMBE01",
+                "print_setting": "DEFAULT",
+            },
             timeout=30
         )
 
@@ -63,7 +68,7 @@ class TestPreFormClient:
         assert "500" in str(exc_info.value)
 
     def test_import_model_success(self):
-        """Test importing an STL model successfully."""
+        """Test importing an STL model through the current JSON path contract."""
         mock_session = Mock()
         mock_response = Mock()
         mock_response.status_code = 200
@@ -82,7 +87,11 @@ class TestPreFormClient:
             result = client.import_model(scene_id="scene-123", stl_path=temp_path)
             
             assert result == {"status": "imported", "model_id": "model-456"}
-            mock_session.post.assert_called_once()
+            mock_session.post.assert_called_once_with(
+                "http://localhost:44388/scene/scene-123/import-model",
+                json={"file": temp_path},
+                timeout=60,
+            )
         finally:
             os.unlink(temp_path)
 
@@ -104,7 +113,10 @@ class TestPreFormClient:
 
             client.import_model(scene_id="scene-123", stl_path=temp_path, preset="tooth_v1")
 
-            assert mock_session.post.call_args.kwargs["data"] == {"preset": "tooth_v1"}
+            assert mock_session.post.call_args.kwargs["json"] == {
+                "file": temp_path,
+                "preset": "tooth_v1",
+            }
         finally:
             os.unlink(temp_path)
 
@@ -168,9 +180,31 @@ class TestPreFormClient:
 
             assert result == {"valid": False, "errors": ["overlap"]}
             mock_get.assert_called_once_with(
-                "http://localhost:44388/scene/scene-123/validate/",
+                "http://localhost:44388/scene/scene-123/print-validation",
                 timeout=30,
             )
+
+    def test_validate_scene_translates_print_validation_payload(self):
+        """Test print-validation results are normalized into valid/errors."""
+        with patch("requests.Session.get") as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "per_model_results": {
+                    "{model-1}": {
+                        "cups": 0,
+                        "has_seamline": False,
+                        "undersupported": False,
+                        "unsupported_minima": 0,
+                    }
+                }
+            }
+            mock_get.return_value = mock_response
+
+            client = PreFormClient("http://localhost:44388")
+            result = client.validate_scene("scene-123")
+
+            assert result == {"valid": True, "errors": []}
 
     def test_validate_scene_raises_on_non_200_response(self):
         """Test validate_scene raises with status and response text on failure."""
@@ -193,18 +227,18 @@ class TestPreFormClient:
         mock_session = Mock()
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"print_id": "print-789", "status": "queued"}
+        mock_response.json.return_value = {"job_id": "{print-789}"}
         mock_session.post.return_value = mock_response
         
         client = PreFormClient()
         client.session = mock_session
         
-        result = client.send_to_printer(scene_id="scene-123", device_id="printer-01")
+        result = client.send_to_printer(scene_id="scene-123", device_id="Form 4", job_name="260421-001")
         
-        assert result == {"print_id": "print-789", "status": "queued"}
+        assert result == {"job_id": "{print-789}", "print_id": "{print-789}"}
         mock_session.post.assert_called_once_with(
-            "http://localhost:44388/print/",
-            json={"scene_id": "scene-123", "device_id": "printer-01"},
+            "http://localhost:44388/scene/scene-123/print/",
+            json={"job_name": "260421-001", "printer": "Form 4"},
             timeout=30
         )
 

--- a/tests/test_preform_handoff.py
+++ b/tests/test_preform_handoff.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from app.config import build_settings
 from app.database import get_upload_row_by_id, init_db, list_print_jobs, persist_upload_session
 from app.main import create_app
+from app.schemas import PreFormSetupStatus
 
 
 class StubPreFormClient:
@@ -62,6 +63,22 @@ def _seed_rows(settings, rows: list[dict]) -> list[int]:
     init_db(settings)
     persisted = persist_upload_session(settings, session_id, rows)
     return [row.row_id for row in persisted if row.row_id is not None]
+
+
+def _ready_setup_status(settings) -> PreFormSetupStatus:
+    return PreFormSetupStatus(
+        readiness="ready",
+        install_path=str(settings.preform_managed_dir),
+        managed_executable_path=str(settings.preform_managed_executable),
+        detected_version="3.57.2.624",
+        expected_version_min=settings.preform_min_supported_version,
+        expected_version_max=settings.preform_max_supported_version,
+        active_configured_source=True,
+        is_running=True,
+        last_health_check_at=datetime.now(timezone.utc).isoformat(),
+        last_error_code=None,
+        last_error_message=None,
+    )
 
 
 def _row_payload(
@@ -159,7 +176,10 @@ def test_send_to_print_creates_preform_batches_and_print_job_records(tmp_path):
     )
 
     stub_client = StubPreFormClient(settings.preform_server_url)
-    with patch("app.services.preform_client.PreFormClient", return_value=stub_client):
+    with patch("app.services.preform_client.PreFormClient", return_value=stub_client), patch(
+        "app.services.preform_setup_service.get_preform_setup_status",
+        return_value=_ready_setup_status(settings),
+    ):
         response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": row_ids})
 
     assert response.status_code == 200
@@ -218,7 +238,10 @@ def test_send_to_print_groups_compatible_mixed_presets_into_one_job(tmp_path):
     )
 
     stub_client = StubPreFormClient(settings.preform_server_url)
-    with patch("app.services.preform_client.PreFormClient", return_value=stub_client):
+    with patch("app.services.preform_client.PreFormClient", return_value=stub_client), patch(
+        "app.services.preform_setup_service.get_preform_setup_status",
+        return_value=_ready_setup_status(settings),
+    ):
         response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": row_ids})
 
     assert response.status_code == 200
@@ -291,7 +314,10 @@ def test_send_to_print_rolls_back_last_case_when_validation_fails(tmp_path):
         {"valid": False, "errors": ["overlap"]},
         {"valid": True, "errors": []},
     ]
-    with patch("app.services.preform_client.PreFormClient", return_value=stub_client):
+    with patch("app.services.preform_client.PreFormClient", return_value=stub_client), patch(
+        "app.services.preform_setup_service.get_preform_setup_status",
+        return_value=_ready_setup_status(settings),
+    ):
         response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": row_ids})
 
     assert response.status_code == 200
@@ -333,7 +359,10 @@ def test_send_to_print_routes_single_invalid_case_to_manual_review(tmp_path):
 
     stub_client = StubPreFormClient(settings.preform_server_url)
     stub_client.validation_results = [{"valid": False, "errors": ["overlap"]}]
-    with patch("app.services.preform_client.PreFormClient", return_value=stub_client):
+    with patch("app.services.preform_client.PreFormClient", return_value=stub_client), patch(
+        "app.services.preform_setup_service.get_preform_setup_status",
+        return_value=_ready_setup_status(settings),
+    ):
         response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": row_ids})
 
     assert response.status_code == 200
@@ -367,7 +396,10 @@ def test_send_to_print_passes_preset_hint_and_selected_printer(tmp_path):
     )
 
     stub_client = StubPreFormClient(settings.preform_server_url)
-    with patch("app.services.preform_client.PreFormClient", return_value=stub_client):
+    with patch("app.services.preform_client.PreFormClient", return_value=stub_client), patch(
+        "app.services.preform_setup_service.get_preform_setup_status",
+        return_value=_ready_setup_status(settings),
+    ):
         response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": row_ids})
 
     assert response.status_code == 200
@@ -399,7 +431,10 @@ def test_send_to_print_returns_502_when_preform_unavailable(tmp_path):
     mock_client.create_scene.side_effect = Exception("Connection refused")
     mock_client.close.return_value = None
 
-    with patch("app.services.preform_client.PreFormClient", return_value=mock_client):
+    with patch("app.services.preform_client.PreFormClient", return_value=mock_client), patch(
+        "app.services.preform_setup_service.get_preform_setup_status",
+        return_value=_ready_setup_status(settings),
+    ):
         response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": row_ids})
 
     assert response.status_code == 502

--- a/tests/test_preform_handoff.py
+++ b/tests/test_preform_handoff.py
@@ -45,7 +45,7 @@ class StubPreFormClient:
             return self.validation_results.pop(0)
         return {"valid": True, "errors": []}
 
-    def send_to_printer(self, scene_id: str, device_id: str):
+    def send_to_printer(self, scene_id: str, device_id: str, job_name: str | None = None):
         self.print_jobs.append((scene_id, device_id))
         return {"print_id": f"print-{len(self.print_jobs)}"}
 
@@ -405,6 +405,37 @@ def test_send_to_print_passes_preset_hint_and_selected_printer(tmp_path):
     assert response.status_code == 200
     assert stub_client.imported_models == [("scene-1", str(case_file), "tooth_v1")]
     assert stub_client.print_jobs == [("scene-1", "printer_form4_001")]
+
+
+def test_send_to_print_defaults_to_form4bl_when_no_printer_selected(tmp_path):
+    settings = _build_settings(tmp_path)
+    app = create_app(settings)
+    client = TestClient(app)
+
+    case_file = tmp_path / "ortho-1.stl"
+    case_file.write_text("solid test\nendsolid test\n", encoding="utf-8")
+    row_ids = _seed_rows(
+        settings,
+        [
+            _row_payload(
+                case_file,
+                case_id="CASE901",
+                preset="Ortho Solid - Flat, No Supports",
+                status="Ready",
+                content_hash="hash-901",
+            ),
+        ],
+    )
+
+    stub_client = StubPreFormClient(settings.preform_server_url)
+    with patch("app.services.preform_client.PreFormClient", return_value=stub_client), patch(
+        "app.services.preform_setup_service.get_preform_setup_status",
+        return_value=_ready_setup_status(settings),
+    ):
+        response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": row_ids})
+
+    assert response.status_code == 200
+    assert stub_client.print_jobs == [("scene-1", "Form 4")]
 
 
 def test_send_to_print_returns_502_when_preform_unavailable(tmp_path):

--- a/tests/test_preform_setup.py
+++ b/tests/test_preform_setup.py
@@ -1,0 +1,164 @@
+"""Phase 1: PreFormServer setup wizard tests (TDD)."""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.config import build_settings
+from app.database import init_db, persist_upload_session
+from app.main import create_app
+
+
+def _build_settings(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    return build_settings(data_dir=data_dir, database_path=data_dir / "andent_web.db")
+
+
+def _build_client(tmp_path: Path) -> tuple[TestClient, object]:
+    settings = _build_settings(tmp_path)
+    init_db(settings)
+    app = create_app(settings)
+    return TestClient(app), settings
+
+
+def _row_payload(file_path: Path, *, status: str = "Ready") -> dict:
+    return {
+        "file_name": file_path.name,
+        "stored_path": str(file_path),
+        "content_hash": f"hash-{file_path.name}",
+        "thumbnail_svg": None,
+        "case_id": "CASE001",
+        "model_type": "Ortho - Solid",
+        "preset": "Ortho Solid - Flat, No Supports",
+        "confidence": "high",
+        "status": status,
+        "dimension_x_mm": 40.0,
+        "dimension_y_mm": 30.0,
+        "dimension_z_mm": 10.0,
+        "volume_ml": None,
+        "structure": None,
+        "structure_confidence": None,
+        "structure_reason": None,
+        "structure_metrics_json": None,
+        "structure_locked": False,
+        "review_required": status != "Ready",
+        "review_reason": None,
+        "printer": None,
+        "person": None,
+    }
+
+
+def _seed_ready_row(settings, tmp_path: Path) -> int:
+    stl_path = tmp_path / "case-1.stl"
+    stl_path.write_text("solid test\nendsolid test\n", encoding="utf-8")
+    session_id = f"session-{datetime.now(timezone.utc).timestamp():.0f}"
+    rows = persist_upload_session(settings, session_id, [_row_payload(stl_path)])
+    assert rows[0].row_id is not None
+    return rows[0].row_id
+
+
+def _build_preform_zip(tmp_path: Path, *, version_text: str = "3.57.2.624") -> Path:
+    archive_path = tmp_path / "PreFormServer_3.57.2.624.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("PreFormServer/PreFormServer.exe", "fake exe payload")
+        archive.writestr("PreFormServer/version.txt", version_text)
+        archive.writestr("PreFormServer/config/default.json", "{}")
+    return archive_path
+
+
+def _build_invalid_zip(tmp_path: Path) -> Path:
+    archive_path = tmp_path / "not-preform.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("README.txt", "missing exe")
+    return archive_path
+
+
+def test_setup_status_defaults_to_not_installed(tmp_path):
+    from app.services.preform_setup_service import get_preform_setup_status
+
+    settings = _build_settings(tmp_path)
+    init_db(settings)
+
+    status = get_preform_setup_status(settings)
+
+    assert status.readiness == "not_installed"
+    assert status.install_path == str(settings.preform_managed_dir)
+    assert status.managed_executable_path == str(settings.preform_managed_executable)
+    assert status.detected_version is None
+    assert status.last_error_code is None
+
+
+def test_install_from_zip_extracts_managed_copy_and_marks_ready(tmp_path):
+    from app.services.preform_setup_service import PreFormSetupService
+
+    settings = _build_settings(tmp_path)
+    settings = replace(settings, preform_min_zip_size_bytes=1)
+    init_db(settings)
+    archive_path = _build_preform_zip(tmp_path)
+    app = create_app(settings)
+
+    def fake_launch(executable_path: Path) -> int:
+        assert executable_path == settings.preform_managed_executable
+        return 4242
+
+    def fake_probe():
+        return {
+            "healthy": True,
+            "version": "3.57.2.624",
+            "code": None,
+            "message": None,
+        }
+
+    manager = PreFormSetupService(app.state.settings)
+    manager._launch_process = fake_launch
+    manager._probe_server = fake_probe
+
+    status = manager.install_from_zip(archive_path)
+
+    assert status.readiness == "ready"
+    assert status.detected_version == "3.57.2.624"
+    assert settings.preform_managed_executable.exists()
+
+
+def test_install_from_zip_rejects_archive_without_preformserver_exe(tmp_path):
+    from app.services.preform_setup_service import PreFormSetupError, PreFormSetupService
+
+    settings = _build_settings(tmp_path)
+    settings = replace(settings, preform_min_zip_size_bytes=1)
+    init_db(settings)
+    archive_path = _build_invalid_zip(tmp_path)
+
+    manager = PreFormSetupService(settings)
+
+    with pytest.raises(PreFormSetupError) as exc_info:
+        manager.install_from_zip(archive_path)
+
+    assert exc_info.value.code == "bad_zip"
+
+
+def test_status_route_returns_not_installed_for_fresh_app(tmp_path):
+    client, _ = _build_client(tmp_path)
+
+    response = client.get("/api/preform-setup/status")
+
+    assert response.status_code == 200
+    assert response.json()["readiness"] == "not_installed"
+
+
+def test_send_to_print_returns_409_when_preform_not_ready(tmp_path):
+    client, settings = _build_client(tmp_path)
+    row_id = _seed_ready_row(settings, tmp_path)
+
+    response = client.post("/api/uploads/rows/send-to-print", json={"row_ids": [row_id]})
+
+    assert response.status_code == 409
+    assert "PreFormServer setup is required" in response.json()["detail"]

--- a/tests/test_release_gate_preset_normalization.py
+++ b/tests/test_release_gate_preset_normalization.py
@@ -1,0 +1,93 @@
+"""Release-gate preset normalization tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.config import build_settings
+from app.database import (
+    bulk_update_upload_rows,
+    init_db,
+    persist_upload_session,
+    update_upload_row,
+)
+
+
+def _build_settings(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    settings = build_settings(data_dir=data_dir, database_path=data_dir / "andent_web.db")
+    init_db(settings)
+    return settings
+
+
+def _seed_row(settings, file_name: str, *, model_type: str, preset: str):
+    stored_path = settings.data_dir / file_name
+    stored_path.parent.mkdir(parents=True, exist_ok=True)
+    stored_path.write_text("solid fixture\nendsolid fixture\n", encoding="utf-8")
+    rows = persist_upload_session(
+        settings,
+        "session-1",
+        [
+            {
+                "file_name": file_name,
+                "stored_path": str(stored_path),
+                "content_hash": f"hash-{file_name}",
+                "thumbnail_svg": None,
+                "case_id": "CASE555",
+                "model_type": model_type,
+                "preset": preset,
+                "confidence": "high",
+                "status": "Ready",
+                "dimension_x_mm": None,
+                "dimension_y_mm": None,
+                "dimension_z_mm": None,
+                "volume_ml": None,
+                "structure": None,
+                "structure_confidence": None,
+                "structure_reason": None,
+                "structure_metrics_json": None,
+                "structure_locked": False,
+                "review_required": False,
+                "review_reason": None,
+                "printer": None,
+                "person": None,
+            }
+        ],
+    )
+    return rows[0].row_id
+
+
+def test_update_upload_row_maps_model_label_to_real_preset(tmp_path):
+    settings = _build_settings(tmp_path)
+    row_id = _seed_row(
+        settings,
+        "20260409_CASE555_Tooth_46.stl",
+        model_type="Tooth",
+        preset="Tooth - With Supports",
+    )
+
+    updated = update_upload_row(settings, row_id, "Ortho - Solid", "Ortho - Solid")
+
+    assert updated is not None
+    assert updated.model_type == "Ortho - Solid"
+    assert updated.preset == "Ortho Solid - Flat, No Supports"
+    assert updated.status == "Ready"
+
+
+def test_bulk_update_upload_rows_maps_model_label_to_real_preset(tmp_path):
+    settings = _build_settings(tmp_path)
+    row_id = _seed_row(
+        settings,
+        "20260409_CASE555_Tooth_46.stl",
+        model_type="Tooth",
+        preset="Tooth - With Supports",
+    )
+
+    rows = bulk_update_upload_rows(settings, [row_id], "Splint", "Splint")
+
+    assert rows[0].model_type == "Splint"
+    assert rows[0].preset == "Splint - Flat, No Supports"
+    assert rows[0].status == "Ready"

--- a/tests/test_release_gate_verify.py
+++ b/tests/test_release_gate_verify.py
@@ -1,0 +1,111 @@
+"""Release-gate verification helper tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from release_gate.helpers.python.release_gate_verify import (
+    latest_print_job,
+    parse_health_response,
+)
+
+
+def _seed_print_job(database_path: Path) -> None:
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE print_jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_name TEXT NOT NULL,
+                scene_id TEXT,
+                print_job_id TEXT,
+                status TEXT NOT NULL,
+                preset TEXT NOT NULL,
+                preset_names_json TEXT,
+                compatibility_key TEXT,
+                case_ids TEXT,
+                manifest_json TEXT,
+                created_at TEXT,
+                updated_at TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO print_jobs (
+                job_name,
+                scene_id,
+                print_job_id,
+                status,
+                preset,
+                preset_names_json,
+                compatibility_key,
+                case_ids,
+                manifest_json,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "260421-001",
+                "scene-123",
+                "print-123",
+                "Queued",
+                "Ortho Solid - Flat, No Supports",
+                json.dumps(["Ortho Solid - Flat, No Supports"]),
+                "form-4bl|precision-model-resin|100",
+                json.dumps(["CASE123"]),
+                json.dumps(
+                    {
+                        "case_ids": ["CASE123"],
+                        "planning_status": "planned",
+                        "import_groups": [
+                            {
+                                "preset_name": "Ortho Solid - Flat, No Supports",
+                                "preform_hint": "ortho_solid_v1",
+                                "files": [
+                                    {
+                                        "file_name": "20260409_CASE123_UnsectionedModel_UpperJaw.stl",
+                                        "preform_hint": "ortho_solid_v1",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ),
+                "2026-04-21T10:00:00Z",
+                "2026-04-21T10:00:00Z",
+            ),
+        )
+        connection.commit()
+
+
+def test_latest_print_job_returns_decoded_manifest_fields(tmp_path):
+    database_path = tmp_path / "gate.db"
+    _seed_print_job(database_path)
+
+    job = latest_print_job(database_path)
+
+    assert job["job_name"] == "260421-001"
+    assert job["scene_id"] == "scene-123"
+    assert job["preset_names"] == ["Ortho Solid - Flat, No Supports"]
+    assert job["case_ids"] == ["CASE123"]
+    assert job["manifest_json"]["planning_status"] == "planned"
+
+
+def test_parse_health_response_prefers_explicit_version_key():
+    parsed = parse_health_response({"status": "ok", "version": "3.57.2.624"})
+
+    assert parsed == {"healthy": True, "version": "3.57.2.624"}
+
+
+def test_parse_health_response_extracts_version_from_free_text():
+    parsed = parse_health_response("PreFormServer build 3.57.2.624 is healthy")
+
+    assert parsed == {"healthy": True, "version": "3.57.2.624"}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": [
+    "playwright.config.ts",
+    "tests/release_gate/**/*.ts",
+    "scripts/release_gate/**/*.mjs"
+  ]
+}


### PR DESCRIPTION
## What changed

This PR adds a managed PreFormServer setup flow to Andent Web and blocks print handoff until the managed dependency is installed, compatible, and healthy.

It also adds the isolated Playwright release-gate workspace under `tests/release_gate/`, including fixtures, runtime helpers, Python verification utilities, and a draft release-gate runner.

## Why it changed

Print handoff previously assumed a working local PreFormServer and failed late. The product now exposes setup state explicitly and routes operators through a managed setup path.

The release gate was still only a design and plan. This PR creates the browser-test surface needed to validate queue interactions, setup gating, and release-time handoff behavior.

## User and developer impact

- Users now see a Setup Center, degraded-state banner, and first-run wizard before print submission.
- `Send to Print` is hard-gated on managed PreFormServer readiness.
- Developers can run Playwright smoke, UI-hook, runtime, and partial release-gate checks locally.
- Full release-gate green still requires a live compatible PreFormServer at `http://127.0.0.1:44388`.

## Root cause

The app had no canonical managed PreFormServer lifecycle and no browser-level release check for the real operator workflow.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/ -q`
- `npx tsc --noEmit`
- `npx playwright test tests/release_gate/smoke.spec.ts tests/release_gate/ui-hooks.spec.ts tests/release_gate/runtime.spec.ts --project=chromium`
- `npx playwright test tests/release_gate/release_gate.spec.ts --project=chromium --grep "ambiguous case stays blocked|dead-port PreForm configuration stays blocked behind setup gating"`
- `npm run test:release-gate` currently reports 2 passing and 2 failing scenarios because the live PreFormServer happy paths require a running service on `127.0.0.1:44388`.
